### PR TITLE
Add package detection to helper

### DIFF
--- a/sigil/__init__.py
+++ b/sigil/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from .core import Sigil
+from .helpers import make_package_prefs
 
-__all__ = ["Sigil"]
+__all__ = ["Sigil", "make_package_prefs"]
 __version__ = "0.1.0"

--- a/sigil/helpers.py
+++ b/sigil/helpers.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from importlib import resources
+import inspect
+from pathlib import Path
+from threading import Lock
+from typing import Callable
+
+from .core import Sigil
+
+
+def make_package_prefs(
+    *,
+    app_name: str,
+    package: str | None = None,
+    defaults_rel: str = "prefs/defaults.ini",
+) -> tuple[Callable, Callable]:
+    """Return (get_pref, set_pref) callables wired to package defaults.
+
+    If ``package`` is omitted, the caller's module name is used.
+    """
+
+    if package is None:
+        frame = inspect.stack()[1].frame
+        package = frame.f_globals.get("__name__")
+        del frame
+        if not isinstance(package, str) or not package:
+            raise ValueError("Could not determine caller package; pass 'package'")
+    lock = Lock()
+    sigil_obj: Sigil | None = None
+    defaults_path: Path = resources.files(package).joinpath(defaults_rel)
+
+    def _lazy() -> Sigil:
+        nonlocal sigil_obj
+        if sigil_obj is None:
+            with lock:
+                if sigil_obj is None:
+                    sigil_obj = Sigil(app_name, default_path=defaults_path)
+        return sigil_obj
+
+    def _get(key: str, *, default=None, cast=None):
+        return _lazy().get_pref(key, default=default, cast=cast)
+
+    def _set(key: str, value, *, scope="user"):
+        return _lazy().set_pref(key, value, scope=scope)
+
+    return _get, _set

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,3 +38,10 @@ def test_context_manager_project(tmp_path: Path):
         assert s.get_pref("setting") == "two"
     # after context manager should revert
     assert s.get_pref("setting") == "one"
+
+
+def test_defaults_from_file(tmp_path: Path):
+    defaults = tmp_path / "defaults.ini"
+    defaults.write_text("[ui]\ntheme=light\n")
+    s = Sigil("app", default_path=defaults)
+    assert s.get_pref("ui.theme") == "light"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import shutil
+from pathlib import Path
+
+from sigil.helpers import make_package_prefs
+
+
+def test_make_package_prefs_explicit(tmp_path: Path):
+    pkg = tmp_path / "pkgexp"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    prefs = pkg / "prefs"
+    prefs.mkdir()
+    (prefs / "defaults.ini").write_text("[ui]\ntheme=light\n")
+    sys.path.insert(0, str(tmp_path))
+    config_dir = Path.home() / ".config" / "myapp_explicit"
+    if config_dir.exists():
+        shutil.rmtree(config_dir)
+    try:
+        get_pref, set_pref = make_package_prefs(app_name="myapp_explicit", package="pkgexp")
+        assert get_pref("ui.theme") == "light"
+        set_pref("ui.theme", "dark")
+        assert get_pref("ui.theme") == "dark"
+    finally:
+        sys.path.pop(0)
+        if config_dir.exists():
+            shutil.rmtree(config_dir)
+
+
+def test_make_package_prefs_infer(tmp_path: Path):
+    pkg = tmp_path / "pkginf"
+    pkg.mkdir()
+    prefs = pkg / "prefs"
+    prefs.mkdir()
+    (prefs / "defaults.ini").write_text("[ui]\ntheme=light\n")
+    (pkg / "__init__.py").write_text(
+        "from sigil.helpers import make_package_prefs\n"
+        "get_pref, set_pref = make_package_prefs(app_name='myapp_infer')\n"
+    )
+    sys.path.insert(0, str(tmp_path))
+    config_dir = Path.home() / ".config" / "myapp_infer"
+    if config_dir.exists():
+        shutil.rmtree(config_dir)
+    try:
+        mod = importlib.import_module("pkginf")
+        assert mod.get_pref("ui.theme") == "light"
+        mod.set_pref("ui.theme", "dark")
+        assert mod.get_pref("ui.theme") == "dark"
+    finally:
+        sys.path.pop(0)
+        sys.modules.pop("pkginf", None)
+        if config_dir.exists():
+            shutil.rmtree(config_dir)
+


### PR DESCRIPTION
## Summary
- infer caller module for `make_package_prefs`
- add tests for inferred package detection
- isolate helper tests to avoid config leakage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68862a18fdf483288aba90bc1d92f4f4