### PR TITLE
Add JSON backend with optional JSON5 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,6 @@ name = "sigil"
 version = "0.1.0"
 requires-python = ">=3.9"
 dependencies = ["appdirs"]
+
+[project.optional-dependencies]
+json5 = ["pyjson5>=1.6"]

--- a/requirements.md
+++ b/requirements.md
@@ -7,7 +7,8 @@ It consolidates every design choice we’ve locked plus the separation-of-concer
 
 Provide a lightweight, extensible preference manager for Python projects that
 	•	merges settings from multiple scopes (default → user → project → env),
-	•	supports multiple on-disk formats (INI first),
+	•       supports multiple on-disk formats (INI first),
+        •       Sigil reads .ini and .json out of the box; install ``sigil[json5]`` for relaxed JSON5 syntax,
 	•	exposes a tiny, intuitive API (get_pref, set_pref),
 	•	keeps UI layers (CLI, Tk GUI) and Secrets entirely decoupled from the core logic.
 

--- a/sigil/backend/__init__.py
+++ b/sigil/backend/__init__.py
@@ -5,13 +5,14 @@ from pathlib import Path
 from typing import Dict, Type
 
 from .base import BaseBackend
-from .ini_backend import IniBackend
 
 _REGISTRY: Dict[str, Type[BaseBackend]] = {}
 
-def register_backend(backend: Type[BaseBackend]) -> None:
+def register_backend(backend: Type[BaseBackend]) -> Type[BaseBackend]:
+    """Register a backend class and return it for decorator use."""
     for suf in backend.suffixes:
         _REGISTRY[suf] = backend
+    return backend
 
 def get_backend_for_path(path: Path) -> BaseBackend:
     backend_cls = _REGISTRY.get(path.suffix.lower())
@@ -19,5 +20,5 @@ def get_backend_for_path(path: Path) -> BaseBackend:
         raise ValueError(f"No backend for {path.suffix}")
     return backend_cls()
 
-# register default ini backend
-register_backend(IniBackend)
+# register default backends
+from . import ini_backend, json_backend  # noqa: F401

--- a/sigil/backend/ini_backend.py
+++ b/sigil/backend/ini_backend.py
@@ -5,8 +5,10 @@ from pathlib import Path
 from typing import Mapping, MutableMapping
 
 from .base import BaseBackend
+from . import register_backend
 
 
+@register_backend
 class IniBackend(BaseBackend):
     suffixes = (".ini",)
 

--- a/sigil/backend/json_backend.py
+++ b/sigil/backend/json_backend.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Mapping, MutableMapping
+
+from .base import BaseBackend
+from . import register_backend
+from ..errors import SigilLoadError
+
+
+def _flatten(src: Mapping[str, object], prefix: str = "") -> MutableMapping[str, object]:
+    out: MutableMapping[str, object] = {}
+    for k, v in src.items():
+        key = f"{prefix}{k}" if not prefix else f"{prefix}.{k}"
+        if isinstance(v, dict):
+            out.update(_flatten(v, key))
+        else:
+            out[key] = v
+    return out
+
+
+def _unflatten(flat: Mapping[str, object]) -> dict:
+    root: dict = {}
+    for dotted, val in flat.items():
+        parts = dotted.split(".")
+        node = root
+        for p in parts[:-1]:
+            node = node.setdefault(p, {})
+        node[parts[-1]] = val
+    return root
+
+
+@register_backend
+class JsonBackend(BaseBackend):
+    """JSON file backend."""
+
+    suffixes = (".json", ".JSON", ".json5")
+
+    def _parse(self, text: str, path: Path) -> Mapping[str, object]:
+        if path.suffix.lower() == ".json5":
+            try:
+                import pyjson5
+                return pyjson5.decode(text)
+            except ModuleNotFoundError:
+                pass
+        return json.loads(text)
+
+    def load(self, path: Path) -> MutableMapping[str, object]:
+        path = Path(path)
+        if not path.exists():
+            return {}
+        raw = path.read_text(encoding="utf-8")
+        if raw.strip() == "":
+            raw = "{}"
+        try:
+            data = self._parse(raw, path)
+        except Exception as exc:  # JSON or JSON5 decoding errors
+            raise SigilLoadError(str(exc)) from exc
+        if not isinstance(data, dict):
+            raise SigilLoadError("Root of JSON prefs must be an object")
+        return _flatten(data)
+
+    def save(self, path: Path, data: Mapping[str, object]) -> None:
+        path = Path(path)
+        nested = _unflatten(data)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as fh:
+            json.dump(nested, fh, indent=2, sort_keys=True, ensure_ascii=False)
+        tmp.replace(path)

--- a/sigil/errors.py
+++ b/sigil/errors.py
@@ -3,3 +3,8 @@ class SigilError(Exception):
 
 class UnknownScopeError(SigilError):
     pass
+
+
+class SigilLoadError(SigilError):
+    """Raised when a backend fails to parse its file."""
+    pass

--- a/tests/test_json_backend.py
+++ b/tests/test_json_backend.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sigil.backend.json_backend import JsonBackend
+from sigil.errors import SigilLoadError
+
+
+def test_json_backend_roundtrip(tmp_path: Path):
+    flat = {"x.y": 1, "x.z": True, "name": "Sigil"}
+    path = tmp_path / "t.json"
+    JsonBackend().save(path, flat)
+    assert JsonBackend().load(path) == flat
+
+
+def test_empty_file(tmp_path: Path):
+    path = tmp_path / "empty.json"
+    path.write_text("", encoding="utf-8")
+    assert JsonBackend().load(path) == {}
+
+
+def test_deep_nesting(tmp_path: Path):
+    flat = {"a.b.c.d": 2}
+    path = tmp_path / "deep.json"
+    JsonBackend().save(path, flat)
+    assert JsonBackend().load(path) == flat
+
+
+def test_invalid_json(tmp_path: Path):
+    path = tmp_path / "bad.json"
+    path.write_text("{ invalid", encoding="utf-8")
+    with pytest.raises(SigilLoadError):
+        JsonBackend().load(path)
+
+
+def test_json5_relaxed(tmp_path: Path):
+    try:
+        import pyjson5  # type: ignore
+    except ModuleNotFoundError:
+        pytest.skip("pyjson5 not installed")
+    path = tmp_path / "relaxed.json5"
+    path.write_text("//c\n{a:1,}\n", encoding="utf-8")
+    assert JsonBackend().load(path) == {"a": 1}
+


### PR DESCRIPTION
## Summary
- implement `JsonBackend` with JSON/JSON5 parsing
- auto-register backends via decorator
- expose new `SigilLoadError`
- document JSON support in requirements
- add optional dependency for JSON5 parsing
- add extensive unit tests for the new backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68863d7f377c832897a8165ded437500