### PR TITLE
Implement CSV metadata loader

### DIFF
--- a/docs/meta_csv.md
+++ b/docs/meta_csv.md
@@ -1,0 +1,31 @@
+# Metadata CSV Specification
+
+`defaults.meta.csv` sits next to `prefs/defaults.ini` and provides GUI hints in spreadsheet-friendly CSV form. The file must be UTF-8 encoded and use a header row. Columns may appear in any order but the common ones are:
+
+```
+key,title,tooltip,type,choices,secret,min,max,order,advanced
+```
+
+- `key` (required) dotted.path identifier
+- `title` label shown in GUIs
+- `tooltip` hover help text – quote the cell if it contains commas or new lines
+- `secret` boolean (`true/false/yes/no/1/0`)
+- `type` one of `str`, `int`, `float`, `bool`, `choice`, `path`, `json`, `yaml`
+- `choices` only when `type=choice`; values separated by `|`
+- `min`/`max` numeric bounds
+- `order` lower numbers appear first
+- `advanced` boolean flag hiding the field until an "Advanced" toggle is used
+
+Unknown columns are preserved for future use.
+
+Example template:
+
+```csv
+key,title,tooltip,type,choices,secret,min,max,order,advanced
+ui.theme,Theme,Light or dark application theme,choice,light|dark|system,, , ,10,
+db.host,Database Host,Hostname or IP for read replica,str,,, , ,20,false
+db.port,Database Port (TCP),,int,,,1024,65535,30,false
+secret.api_key,API Key,Stored securely in OS keychain,str,,true, , ,90,true
+```
+
+Cells containing commas must be quoted, e.g. `"The quick, brown fox"`. The pipe character `|` cannot appear inside a choice value—use JSON metadata instead if required.

--- a/sigil/errors.py
+++ b/sigil/errors.py
@@ -8,3 +8,8 @@ class UnknownScopeError(SigilError):
 class SigilLoadError(SigilError):
     """Raised when a backend fails to parse its file."""
     pass
+
+
+class SigilMetaError(SigilError):
+    """Raised when preference metadata is malformed."""
+    pass

--- a/sigil/helpers.py
+++ b/sigil/helpers.py
@@ -2,11 +2,26 @@ from __future__ import annotations
 
 from importlib import resources
 import inspect
+import json
+import csv
+import logging
 from pathlib import Path
 from threading import Lock
-from typing import Callable
+from typing import Callable, Mapping
+
+try:
+    from distutils.util import strtobool  # type: ignore
+except Exception:  # pragma: no cover - fallback for Python >=3.12
+    def strtobool(val: str) -> int:
+        val = val.lower()
+        if val in {"y", "yes", "t", "true", "on", "1"}:
+            return 1
+        if val in {"n", "no", "f", "false", "off", "0"}:
+            return 0
+        raise ValueError(f"invalid truth value {val!r}")
 
 from .core import Sigil
+from .errors import SigilMetaError
 
 
 def make_package_prefs(
@@ -45,3 +60,150 @@ def make_package_prefs(
         return _lazy().set_pref(key, value, scope=scope)
 
     return _get, _set
+
+
+def _parse_json(path: Path) -> dict[str, dict]:
+    """Parse JSON metadata file into a mapping."""
+    try:
+        with path.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception as exc:  # pragma: no cover - delegated to json
+        raise SigilMetaError(str(exc)) from exc
+    if not isinstance(data, Mapping):
+        raise SigilMetaError("Metadata root must be a JSON object")
+    meta: dict[str, dict] = {}
+    for key, val in data.items():
+        if key in meta:
+            raise SigilMetaError(f"duplicate key '{key}'")
+        if not isinstance(val, Mapping):
+            raise SigilMetaError(f"entry for '{key}' must be an object")
+        meta[key] = dict(val)
+    return meta
+
+
+def _parse_csv(path: Path) -> dict[str, dict]:
+    """Parse CSV metadata following the spec."""
+
+    logger = logging.getLogger("sigil")
+
+    with path.open(encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        if reader.fieldnames is None:
+            raise SigilMetaError(f"{path}: missing header row")
+        fieldnames = [name.lower() for name in reader.fieldnames]
+        reader.fieldnames = fieldnames
+
+        meta: dict[str, dict] = {}
+
+        def parse_bool(val: str) -> bool:
+            try:
+                return strtobool(val.strip().lower()) == 1
+            except Exception as exc:
+                raise SigilMetaError(f"{path} invalid boolean '{val}'") from exc
+
+        def parse_num(val: str):
+            val = val.strip()
+            if val == "":
+                return None
+            try:
+                return int(val)
+            except ValueError:
+                try:
+                    return float(val)
+                except ValueError as exc:
+                    raise SigilMetaError(
+                        f"{path} invalid numeric value '{val}'"
+                    ) from exc
+
+        known = {
+            "key",
+            "title",
+            "tooltip",
+            "secret",
+            "type",
+            "choices",
+            "min",
+            "max",
+            "order",
+            "advanced",
+        }
+
+        for lineno, row in enumerate(reader, start=2):
+            row = {k.lower(): (v or "") for k, v in row.items()}
+
+            key = row.get("key", "").strip()
+            if not key:
+                raise SigilMetaError(f"{path}:{lineno} missing 'key' value")
+            if key in meta:
+                raise SigilMetaError(f"duplicate key '{key}'")
+
+            entry: dict[str, object] = {}
+
+            if row.get("title"):
+                entry["title"] = row["title"].strip()
+            if row.get("tooltip"):
+                entry["tooltip"] = row["tooltip"].strip()
+            if row.get("secret"):
+                entry["secret"] = parse_bool(row["secret"])
+            if row.get("type"):
+                entry["type"] = row["type"].strip().lower()
+                allowed_types = {
+                    "str",
+                    "int",
+                    "float",
+                    "bool",
+                    "choice",
+                    "path",
+                    "json",
+                    "yaml",
+                }
+                if entry["type"] not in allowed_types:
+                    logger.warning("unknown type value '%s'", entry["type"])
+            if row.get("choices"):
+                choices = [p.strip() for p in row["choices"].split("|")]
+                if not isinstance(choices, list):
+                    raise SigilMetaError("choices split did not produce a list")
+                entry["choices"] = choices
+                if entry.get("type") != "choice":
+                    logger.warning("choices present but type != choice")
+            num = parse_num(row.get("min", ""))
+            if num is not None:
+                entry["min"] = num
+            num = parse_num(row.get("max", ""))
+            if num is not None:
+                entry["max"] = num
+            num = parse_num(row.get("order", ""))
+            if num is not None:
+                entry["order"] = num
+            if row.get("advanced"):
+                entry["advanced"] = parse_bool(row["advanced"])
+
+            if (
+                "min" in entry
+                and "max" in entry
+                and isinstance(entry["min"], (int, float))
+                and isinstance(entry["max"], (int, float))
+                and entry["min"] > entry["max"]
+            ):
+                raise SigilMetaError(f"{path}:{lineno} min > max")
+
+            # preserve any unknown columns
+            for col, val in row.items():
+                if col not in known and val.strip() != "":
+                    entry[col] = val.strip()
+
+            meta[key] = entry
+
+    return meta
+
+
+def load_meta(path: Path) -> dict[str, dict]:
+    """Load preference metadata from a JSON or CSV file."""
+
+    path = Path(path)
+    ext = path.suffix.lower()
+    if ext == ".csv":
+        return _parse_csv(path)
+    elif ext == ".json":
+        return _parse_json(path)
+    raise SigilMetaError(f"unsupported metadata format: {path}")

--- a/tests/test_meta_csv.py
+++ b/tests/test_meta_csv.py
@@ -1,0 +1,66 @@
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from sigil.helpers import load_meta
+from sigil.errors import SigilMetaError
+
+
+def test_csv_happy_path(tmp_path: Path):
+    csv_text = textwrap.dedent(
+        """\
+        key,title,tooltip,type,choices,secret,min,max,order,advanced
+        ui.theme,Theme,"Line1, line2",choice,light|dark|system,,, ,10,
+        db.port,Database Port,,int,,,1024,65535,20,false
+        secret.api_key,API Key,Stored securely in OS keychain,str,,true,, ,30,true
+        """
+    )
+    path = tmp_path / "defaults.meta.csv"
+    path.write_text(csv_text, encoding="utf-8")
+
+    meta = load_meta(path)
+    assert meta["ui.theme"]["choices"] == ["light", "dark", "system"]
+    assert meta["db.port"]["min"] == 1024
+    assert meta["db.port"]["max"] == 65535
+    assert meta["secret.api_key"]["secret"] is True
+    assert meta["secret.api_key"]["advanced"] is True
+    assert meta["ui.theme"]["tooltip"] == "Line1, line2"
+
+
+def test_csv_quoted_tooltip(tmp_path: Path):
+    csv_text = "key,title,tooltip\n" "a,Alpha,\"Line1,\nline2\"\n"
+    path = tmp_path / "meta.csv"
+    path.write_text(csv_text, encoding="utf-8")
+
+    meta = load_meta(path)
+    assert meta["a"]["tooltip"] == "Line1,\nline2"
+
+
+def test_csv_duplicate_key(tmp_path: Path):
+    csv_text = "key\nfoo\nfoo\n"
+    path = tmp_path / "meta.csv"
+    path.write_text(csv_text, encoding="utf-8")
+
+    with pytest.raises(SigilMetaError):
+        load_meta(path)
+
+
+def test_csv_min_gt_max(tmp_path: Path):
+    csv_text = "key,min,max\nfoo,10,5\n"
+    path = tmp_path / "meta.csv"
+    path.write_text(csv_text, encoding="utf-8")
+
+    with pytest.raises(SigilMetaError):
+        load_meta(path)
+
+
+def test_csv_invalid_number(tmp_path: Path):
+    csv_text = "key,min\nfoo,abc\n"
+    path = tmp_path / "meta.csv"
+    path.write_text(csv_text, encoding="utf-8")
+
+    with pytest.raises(SigilMetaError):
+        load_meta(path)
+
+


### PR DESCRIPTION
## Summary
- support metadata files in CSV format via `_parse_csv`
- handle booleans/numerics and validation in CSV parsing
- expose `load_meta` helper able to read CSV or JSON
- add `SigilMetaError` exception type
- document CSV spec and provide example template
- add comprehensive tests for metadata CSV loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688642ee87b8832888af1db49f76dc35