### PR TITLE
Implement secrets support

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,51 @@
+# Storing Secrets
+
+Sigil can store sensitive values in a dedicated secrets chain. By default it tries the
+operating system keyring first, then an encrypted JSON file, and finally
+environment variables prefixed with `SIGIL_SECRET_<APP>_`.
+
+## Quick start
+
+Install the extras and set a secret value:
+
+```bash
+pip install sigil[secrets-crypto]
+sigil secret set secret.api_key mysecret --app myapp
+```
+
+Retrieve it later:
+
+```bash
+sigil secret get secret.api_key --app myapp --reveal
+```
+
+## CI usage
+
+For headless environments define the value directly:
+
+```bash
+export SIGIL_SECRET_MYAPP_SECRET_API_KEY=mysecret
+```
+
+If using an encrypted file provider you can unlock via `SIGIL_MASTER_PWD`.
+
+## Encrypted vault workflow
+
+An encrypted vault lives beside your normal settings file with a `.enc.json`
+suffix. Unlock it by running:
+
+```bash
+sigil secret unlock --app myapp
+```
+
+Rotate or change the master key by writing a new secret after unlocking.
+
+```
+```
+
+| Provider        | Security Level |
+|-----------------|----------------|
+| Keyring         | High           |
+| Encrypted file  | Medium         |
+| Environment var | Low            |
+|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = ["appdirs"]
 [project.optional-dependencies]
 json5 = ["pyjson5>=1.6"]
 gui = []
+secrets = ["keyring>=25"]
+secrets-crypto = ["keyring>=25", "cryptography>=42"]
 
 [project.scripts]
 sigil = "sigil.cli:main"

--- a/sigil/cli.py
+++ b/sigil/cli.py
@@ -20,6 +20,22 @@ def build_parser() -> argparse.ArgumentParser:
     set_p.add_argument("--app", required=True)
     set_p.add_argument("--scope", choices=["user", "project"], default="user")
 
+    secret_p = sub.add_parser("secret")
+    secret_sub = secret_p.add_subparsers(dest="scmd", required=True)
+
+    sec_get = secret_sub.add_parser("get")
+    sec_get.add_argument("key")
+    sec_get.add_argument("--app", required=True)
+    sec_get.add_argument("--reveal", action="store_true")
+
+    sec_set = secret_sub.add_parser("set")
+    sec_set.add_argument("key")
+    sec_set.add_argument("value")
+    sec_set.add_argument("--app", required=True)
+
+    sec_unlock = secret_sub.add_parser("unlock")
+    sec_unlock.add_argument("--app", required=True)
+
     return parser
 
 
@@ -36,6 +52,25 @@ def main(argv: list[str] | None = None) -> int:
     elif args.cmd == "set":
         sigil.set_pref(args.key, args.value, scope=args.scope)
         return 0
+    elif args.cmd == "secret":
+        if args.scmd == "get":
+            val = sigil.get_pref(args.key)
+            if val is None:
+                return 1
+            if args.reveal:
+                print(val)
+            else:
+                print("*" * 8)
+            return 0
+        elif args.scmd == "set":
+            try:
+                sigil.set_pref(args.key, args.value)
+            except Exception:
+                return 1
+            return 0
+        elif args.scmd == "unlock":
+            sigil._secrets.unlock()
+            return 0
     return 1
 
 

--- a/sigil/errors.py
+++ b/sigil/errors.py
@@ -13,3 +13,13 @@ class SigilLoadError(SigilError):
 class SigilMetaError(SigilError):
     """Raised when preference metadata is malformed."""
     pass
+
+
+class SigilWriteError(SigilError):
+    """Raised when attempting to write and the target is read-only."""
+    pass
+
+
+class SigilSecretsError(SigilError):
+    """Raised for errors in the secrets subsystem."""
+    pass

--- a/sigil/secrets/__init__.py
+++ b/sigil/secrets/__init__.py
@@ -1,1 +1,263 @@
-"""Secret providers (future)."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Protocol, Sequence
+
+from ..errors import SigilSecretsError
+
+logger = logging.getLogger("sigil.secrets")
+
+
+class SecretProvider(Protocol):
+    """Protocol for secret providers."""
+
+    def available(self) -> bool:
+        """Return True if the provider can be used at runtime."""
+
+    def can_write(self) -> bool:
+        """Return True if the provider currently allows writes."""
+
+    def get(self, dotted_key: str) -> str | None:
+        """Return secret value if present or ``None``."""
+
+    def set(self, dotted_key: str, value: str) -> None:
+        """Store secret value or raise :class:`SigilSecretsError`."""
+
+
+class SecretChain:
+    """Chain multiple providers with precedence."""
+
+    def __init__(self, providers: Sequence[SecretProvider]):
+        self._providers = list(providers)
+
+    def available(self) -> bool:
+        return any(p.available() for p in self._providers)
+
+    def can_write(self) -> bool:
+        return any(p.available() and p.can_write() for p in self._providers)
+
+    def get(self, dotted_key: str) -> str | None:
+        for prov in self._providers:
+            if not prov.available():
+                logger.debug("provider %s unavailable", prov.__class__.__name__)
+                continue
+            val = prov.get(dotted_key)
+            if val is not None:
+                return val
+        logger.debug("secret %s not found", dotted_key)
+        return None
+
+    def set(self, dotted_key: str, value: str) -> None:
+        for prov in self._providers:
+            if prov.available() and prov.can_write():
+                prov.set(dotted_key, value)
+                return
+        raise SigilSecretsError("No write-capable secret provider")
+
+    # convenience for CLI
+    def unlock(self) -> None:
+        for prov in self._providers:
+            unlock = getattr(prov, "unlock", None)
+            if callable(unlock):
+                try:
+                    unlock()
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.error("unlock failed: %s", exc)
+
+
+class KeyringProvider:
+    """Secrets stored via the system keyring."""
+
+    def __init__(self, domain: str = "sigil") -> None:
+        self.domain = domain
+        try:
+            import keyring  # type: ignore
+            from keyring.backends import fail
+            self._keyring = keyring
+            self._fail = fail
+        except Exception:  # pragma: no cover - keyring missing
+            self._keyring = None
+            self._fail = None
+
+    def available(self) -> bool:
+        if self._keyring is None:
+            return False
+        return not isinstance(self._keyring.get_keyring(), self._fail.Keyring)
+
+    def can_write(self) -> bool:
+        return self.available()
+
+    def get(self, dotted_key: str) -> str | None:
+        if not self.available():
+            return None
+        return self._keyring.get_password(self.domain, dotted_key)
+
+    def set(self, dotted_key: str, value: str) -> None:
+        if not self.available():
+            raise SigilSecretsError("Keyring backend unavailable")
+        self._keyring.set_password(self.domain, dotted_key, value)
+
+
+class EnvSecretProvider:
+    """Read-only provider using environment variables."""
+
+    def __init__(self, app_name: str) -> None:
+        self._prefix = f"SIGIL_SECRET_{app_name.upper()}_"
+
+    def available(self) -> bool:  # pragma: no cover - trivial
+        return True
+
+    def can_write(self) -> bool:
+        return False
+
+    def get(self, dotted_key: str) -> str | None:
+        env_key = self._prefix + dotted_key.replace(".", "_").upper()
+        return os.environ.get(env_key)
+
+    def set(self, dotted_key: str, value: str) -> None:
+        raise SigilSecretsError("Environment provider is read-only")
+
+
+class EncryptedFileProvider:
+    """AES-GCM encrypted JSON file provider."""
+
+    def __init__(
+        self,
+        path: Path | str | None,
+        *,
+        master_key: bytes | str | None = None,
+        prompt: bool = True,
+        required: bool = True,
+    ) -> None:
+        self.path = Path(path) if path else None
+        self.prompt = prompt
+        self.required = required
+        self._password: bytes | None = None
+        try:
+            from cryptography.hazmat.primitives.ciphers.aead import AESGCM  # noqa:F401
+            self._have_crypto = True
+        except Exception:  # pragma: no cover - cryptography missing
+            self._have_crypto = False
+        self._discover_password(master_key)
+
+    # ----- basic helpers -----
+    def available(self) -> bool:
+        return bool(self._have_crypto and self.path and self.path.exists())
+
+    def can_write(self) -> bool:
+        return self.available() and self._password is not None
+
+    # ----- discovery & unlocking -----
+    def _discover_password(self, master_key: bytes | str | None) -> None:
+        if not self._have_crypto:
+            return
+        password: bytes | None = None
+        if master_key is not None:
+            password = master_key if isinstance(master_key, bytes) else master_key.encode()
+        elif os.environ.get("SIGIL_MASTER_PWD"):
+            password = os.environ["SIGIL_MASTER_PWD"].encode()
+        else:
+            try:
+                import keyring  # type: ignore
+
+                val = keyring.get_password("sigil", f"master::{self.path}") if self.path else None
+                if val:
+                    password = val.encode()
+            except Exception:  # pragma: no cover - keyring missing
+                pass
+        if password is None and self.prompt and os.isatty(0):  # pragma: no cover - interactive
+            try:
+                import getpass
+
+                password = getpass.getpass("Master password: ").encode()
+            except Exception:
+                pass
+        self._password = password
+
+    def unlock(self) -> None:
+        if self._password is None:
+            self._discover_password(None)
+
+    # ----- file helpers -----
+    def _derive_key(self, salt: bytes) -> bytes:
+        from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+
+        if self._password is None:
+            raise SigilSecretsError("Vault locked")
+        kdf = Scrypt(salt=salt, length=32, n=2 ** 15, r=8, p=1)
+        return kdf.derive(self._password)
+
+    def _decrypt_file(self) -> dict[str, str]:
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+        if not self.path:
+            return {}
+        raw = json.loads(self.path.read_text())
+        salt = bytes.fromhex(raw["salt"])
+        nonce = bytes.fromhex(raw["nonce"])
+        cipher = bytes.fromhex(raw["cipher"])
+        key = self._derive_key(salt)
+        data = AESGCM(key).decrypt(nonce, cipher, None)
+        return json.loads(data.decode())
+
+    def _write_file(self, data: dict[str, str]) -> None:
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+        if not self.path:
+            raise SigilSecretsError("No file path configured")
+        salt = os.urandom(16)
+        key = self._derive_key(salt)
+        nonce = os.urandom(12)
+        cipher = AESGCM(key).encrypt(nonce, json.dumps(data).encode(), None)
+        obj = {
+            "kdf": "scrypt",
+            "salt": salt.hex(),
+            "nonce": nonce.hex(),
+            "cipher": cipher.hex(),
+        }
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_text(json.dumps(obj), encoding="utf-8")
+        tmp.replace(self.path)
+
+    # ----- public API -----
+    def get(self, dotted_key: str) -> str | None:
+        if not self.available():
+            return None
+        if self._password is None:
+            logger.debug("vault locked; cannot read %s", dotted_key)
+            return None
+        try:
+            data = self._decrypt_file()
+            return data.get(dotted_key)
+        except Exception as exc:  # pragma: no cover - corruption
+            logger.error("failed to decrypt vault: %s", exc)
+            raise SigilSecretsError(str(exc))
+
+    def set(self, dotted_key: str, value: str) -> None:
+        if not self.available():
+            raise SigilSecretsError("Vault unavailable")
+        if self._password is None:
+            logger.warning("vault locked when attempting write")
+            raise SigilSecretsError("Vault locked")
+        try:
+            data = self._decrypt_file() if self.path.exists() else {}
+            data[dotted_key] = value
+            self._write_file(data)
+        except SigilSecretsError:
+            raise
+        except Exception as exc:  # pragma: no cover - corruption
+            logger.error("failed to write vault: %s", exc)
+            raise SigilSecretsError(str(exc))
+
+
+__all__ = [
+    "SecretProvider",
+    "SecretChain",
+    "KeyringProvider",
+    "EnvSecretProvider",
+    "EncryptedFileProvider",
+]

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from sigil.secrets import KeyringProvider, EnvSecretProvider, EncryptedFileProvider
+from sigil.errors import SigilSecretsError
+
+
+def test_keyring_roundtrip(monkeypatch):
+    store = {}
+
+    class DummyKeyring:
+        class Keyring:  # stand-in for fail.Keyring
+            pass
+
+    dummy = types.SimpleNamespace(
+        get_keyring=lambda: DummyKeyring(),
+        set_password=lambda dom, key, val: store.__setitem__((dom, key), val),
+        get_password=lambda dom, key: store.get((dom, key)),
+    )
+    monkeypatch.setitem(sys.modules, "keyring", dummy)
+    monkeypatch.setitem(sys.modules, "keyring.backends", types.SimpleNamespace(fail=DummyKeyring))
+
+    p = KeyringProvider()
+    assert p.available()
+    p.set("secret.api", "val")
+    assert p.get("secret.api") == "val"
+
+
+def test_env_provider(monkeypatch):
+    monkeypatch.setenv("SIGIL_SECRET_APP_SECRET_TOKEN", "abc")
+    p = EnvSecretProvider("app")
+    assert p.get("secret.token") == "abc"
+    assert not p.can_write()
+
+
+@pytest.mark.skipif(not EncryptedFileProvider(Path("x"))._have_crypto, reason="cryptography missing")
+def test_encrypted_file_locked(tmp_path, monkeypatch):
+    path = tmp_path / "vault.enc.json"
+    p = EncryptedFileProvider(path, master_key="pw")
+    p.set("secret.token", "one")
+
+    locked = EncryptedFileProvider(path)
+    assert locked.get("secret.token") is None
+    with pytest.raises(SigilSecretsError):
+        locked.set("secret.token", "two")
+
+    monkeypatch.setenv("SIGIL_MASTER_PWD", "pw")
+    unlocked = EncryptedFileProvider(path, prompt=False)
+    assert unlocked.get("secret.token") == "one"
+    unlocked.set("secret.token", "two")
+    assert unlocked.get("secret.token") == "two"
+    monkeypatch.delenv("SIGIL_MASTER_PWD")
+
+def test_secret_precedence_env_overrides_files(tmp_path, monkeypatch):
+    user = tmp_path / "user.ini"
+    user.write_text("[global]\nsecret.token=from_user\n")
+    monkeypatch.setenv("SIGIL_SECRET_APP_SECRET_TOKEN", "from_env")
+    from sigil.core import Sigil
+
+    s = Sigil("app", user_scope=user, project_scope=tmp_path / "p.ini")
+    assert s.get_pref("secret.token") == "from_env"
+


### PR DESCRIPTION
## Summary
- implement secret providers (keyring, encrypted file, env) and SecretChain
- extend `Sigil` core to consult secret chain before file scopes
- add CLI commands under `sigil secret`
- document storing secrets
- add optional dependency groups and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68865144ffa88328bde008e989470c79