### PR TITLE
Add Docker-based testing harness

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY sigil /app/sigil
+COPY appdirs /app/appdirs
+COPY tests /app/tests
+COPY pyproject.toml /app/
+RUN pip install -e .[secrets] pytest
+CMD []

--- a/tests/docker/README_docker.md
+++ b/tests/docker/README_docker.md
@@ -1,0 +1,37 @@
+# Docker-based testing for Sigil
+
+This directory provides a lightweight container workflow to run the test suite
+and experiment with the CLI in isolation.
+
+## Build image & run unit tests
+```sh
+cd tests/docker
+./run_pytest.sh
+```
+
+## Quick one-off CLI inside container
+```sh
+docker run --rm -it sigil-test bash
+```
+
+## Headless secrets demo
+```sh
+./smoke_cli.sh
+```
+
+### Mount the repo for rapid development
+```sh
+docker run --rm -it -v "$(pwd)":/app sigil-test bash
+pip install -e .  # re-install after edits
+```
+
+### GitHub Actions example
+```yaml
+jobs:
+  docker-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Sigil tests in Docker
+        run: tests/docker/run_pytest.sh
+```

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec "$@"

--- a/tests/docker/run_pytest.sh
+++ b/tests/docker/run_pytest.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -eu
+SCRIPT_DIR="$(dirname "$0")"
+docker build -t sigil-test -f "$SCRIPT_DIR/Dockerfile" "$SCRIPT_DIR/../.."
+docker run --rm sigil-test pytest -q

--- a/tests/docker/smoke_cli.sh
+++ b/tests/docker/smoke_cli.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -eu
+docker run --rm \
+  -e SIGIL_SECRET_DEMO_SECRET_API_KEY=abc123 \
+  sigil-test sigil get secret.api_key --app demo


### PR DESCRIPTION
## Summary
- add Dockerfile to build isolated test image
- provide helper scripts for running pytest and a secrets demo
- document container workflow for local dev and CI

## Testing
- `pytest -q`
- `tests/docker/run_pytest.sh` *(fails: `docker: not found`)*
- `tests/docker/smoke_cli.sh` *(fails: `docker: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688668b021608328a0ec7f8079958780