### PR TITLE
Add typed helpers and env export

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: sigil-meta-validate
+        name: Sigil metadata validator
+        entry: python tools/validate_meta.py accio_data prefs/defaults.meta.csv
+        language: python
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Sigil
+
+Preference management for small apps.
+
+```bash
+eval "$(sigil export --app demo)"  # shell-friendly
+```
+
+Typed helper methods are available for convenient access:
+`Sigil.get_int()`, `get_float()`, `get_bool()`.

--- a/sigil/__init__.py
+++ b/sigil/__init__.py
@@ -4,5 +4,20 @@ from __future__ import annotations
 from .core import Sigil
 from .helpers import make_package_prefs
 
-__all__ = ["Sigil", "make_package_prefs"]
+__all__ = ["Sigil", "make_package_prefs", "get_int", "get_float", "get_bool"]
 __version__ = "0.1.0"
+
+
+def get_int(key: str, *, app: str, default: int | None = None) -> int | None:
+    """Return typed integer preference for ``app``."""
+    return Sigil(app).get_int(key, default=default)
+
+
+def get_float(key: str, *, app: str, default: float | None = None) -> float | None:
+    """Return typed float preference for ``app``."""
+    return Sigil(app).get_float(key, default=default)
+
+
+def get_bool(key: str, *, app: str, default: bool | None = None) -> bool | None:
+    """Return typed boolean preference for ``app``."""
+    return Sigil(app).get_bool(key, default=default)

--- a/sigil/cli.py
+++ b/sigil/cli.py
@@ -36,6 +36,11 @@ def build_parser() -> argparse.ArgumentParser:
     sec_unlock = secret_sub.add_parser("unlock")
     sec_unlock.add_argument("--app", required=True)
 
+    export_p = sub.add_parser("export")
+    export_p.add_argument("--app", required=True)
+    export_p.add_argument("--prefix", default="SIGIL_")
+    export_p.add_argument("--json", action="store_true")
+
     return parser
 
 
@@ -51,6 +56,16 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     elif args.cmd == "set":
         sigil.set_pref(args.key, args.value, scope=args.scope)
+        return 0
+    elif args.cmd == "export":
+        mapping = sigil.export_env(prefix=args.prefix)
+        if args.json:
+            import json
+
+            print(json.dumps(mapping))
+        else:
+            for k, v in mapping.items():
+                print(f"{k}={v}")
         return 0
     elif args.cmd == "secret":
         if args.scmd == "get":

--- a/tests/test_export_env.py
+++ b/tests/test_export_env.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from sigil.core import Sigil
+
+
+class DummyProvider:
+    def __init__(self, store):
+        self.store = store
+
+    def available(self):
+        return True
+
+    def can_write(self):
+        return True
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, val):
+        self.store[key] = val
+
+
+def test_export_env_snake_and_prefix(tmp_path):
+    s = Sigil(
+        "demo",
+        defaults={"ui.theme": "dark", "color": "blue"},
+        user_scope=tmp_path / "u.ini",
+        project_scope=tmp_path / "p.ini",
+    )
+    mapping = s.export_env(prefix="MY_")
+    assert mapping["MY_DEMO_UI_THEME"] == "dark"
+    assert mapping["MY_DEMO_COLOR"] == "blue"
+
+
+def test_export_env_secret_omission(tmp_path):
+    provider = DummyProvider({"secret.token": "tok"})
+    s = Sigil(
+        "demo",
+        defaults={"secret.token": ""},
+        user_scope=tmp_path / "u.ini",
+        project_scope=tmp_path / "p.ini",
+        secrets=[provider],
+    )
+    mapping = s.export_env()
+    assert "SIGIL_DEMO_SECRET_TOKEN" not in mapping
+    mapping = s.export_env(include_secrets=True)
+    assert mapping["SIGIL_DEMO_SECRET_TOKEN"] == "tok"

--- a/tests/test_typed_getters.py
+++ b/tests/test_typed_getters.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from sigil.core import Sigil
+
+
+def test_typed_getters_happy():
+    s = Sigil("app", defaults={"num": "42", "flt": "3.14", "flag": "true"})
+    assert s.get_int("num") == 42
+    assert s.get_float("flt") == 3.14
+    assert s.get_bool("flag") is True
+    s2 = Sigil("app2", defaults={"flag": "0"})
+    assert s2.get_bool("flag") is False
+
+
+def test_typed_getters_type_error():
+    s = Sigil("app", defaults={"num": "abc", "flag": "maybe"})
+    with pytest.raises(TypeError):
+        s.get_int("num")
+    with pytest.raises(TypeError):
+        s.get_bool("flag")

--- a/tools/validate_meta.py
+++ b/tools/validate_meta.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import logging
+import sys
+from importlib import resources
+from pathlib import Path
+
+from sigil.helpers import load_meta
+from sigil.errors import SigilMetaError
+
+
+class WarnCounter(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.count = 0
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if record.levelno >= logging.WARNING:
+            self.count += 1
+
+
+def validate(package: str, rel_path: str) -> int:
+    path = resources.files(package).joinpath(rel_path)
+    logger = logging.getLogger("sigil")
+    handler = WarnCounter()
+    logger.addHandler(handler)
+    try:
+        load_meta(Path(path))
+    except SigilMetaError as exc:
+        print(f"{path}: {exc}")
+        return 1
+    finally:
+        logger.removeHandler(handler)
+    if handler.count:
+        print(f"{path}: {handler.count} warning(s)")
+        return 1
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) % 2 or not argv:
+        print("usage: validate_meta.py package path [package path ...]")
+        return 1
+    rc = 0
+    for i in range(0, len(argv), 2):
+        pkg = argv[i]
+        path = argv[i + 1]
+        rc |= validate(pkg, path)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- implement typed getter helpers and env export in core
- re-export typed getters in top-level package
- extend CLI with `export` command
- add metadata validation script and precommit hook
- document env export and typed getters
- add tests for typed getters and env export

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68866c641e5c8328adf0e32540a2c696