### PR TITLE
Add YAML backend

### DIFF
--- a/sigil/backend/__init__.py
+++ b/sigil/backend/__init__.py
@@ -21,4 +21,4 @@ def get_backend_for_path(path: Path) -> BaseBackend:
     return backend_cls()
 
 # register default backends
-from . import ini_backend, json_backend  # noqa: F401
+from . import ini_backend, json_backend, yaml_backend  # noqa: F401

--- a/sigil/backend/yaml_backend.py
+++ b/sigil/backend/yaml_backend.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, MutableMapping
+
+from .base import BaseBackend
+from . import register_backend
+from ..errors import SigilLoadError
+
+
+def _flatten(src: Mapping[str, object], prefix: str = "") -> MutableMapping[str, object]:
+    out: MutableMapping[str, object] = {}
+    for k, v in src.items():
+        key = f"{prefix}{k}" if not prefix else f"{prefix}.{k}"
+        if isinstance(v, dict):
+            out.update(_flatten(v, key))
+        else:
+            out[key] = v
+    return out
+
+
+def _unflatten(flat: Mapping[str, object]) -> dict:
+    root: dict = {}
+    for dotted, val in flat.items():
+        parts = dotted.split(".")
+        node = root
+        for p in parts[:-1]:
+            node = node.setdefault(p, {})
+        node[parts[-1]] = val
+    return root
+
+
+@register_backend
+class YamlBackend(BaseBackend):
+    """YAML file backend."""
+
+    suffixes = (".yaml", ".yml")
+
+    def _require_yaml(self):
+        try:
+            import yaml  # type: ignore
+        except ModuleNotFoundError as exc:
+            raise SigilLoadError("PyYAML is required for YAML backend") from exc
+        return yaml
+
+    def load(self, path: Path) -> MutableMapping[str, object]:
+        yaml = self._require_yaml()
+        path = Path(path)
+        if not path.exists():
+            return {}
+        raw = path.read_text(encoding="utf-8")
+        if raw.strip() == "":
+            return {}
+        try:
+            data = yaml.safe_load(raw) or {}
+        except Exception as exc:
+            raise SigilLoadError(str(exc)) from exc
+        if not isinstance(data, dict):
+            raise SigilLoadError("Root of YAML prefs must be a mapping")
+        return _flatten(data)
+
+    def save(self, path: Path, data: Mapping[str, object]) -> None:
+        yaml = self._require_yaml()
+        path = Path(path)
+        nested = _unflatten(data)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as fh:
+            yaml.safe_dump(nested, fh, sort_keys=True, allow_unicode=True)
+        tmp.replace(path)

--- a/tests/test_yaml_backend.py
+++ b/tests/test_yaml_backend.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+
+from sigil.backend.yaml_backend import YamlBackend
+from sigil.errors import SigilLoadError
+
+
+def require_pyyaml():
+    try:
+        import yaml  # type: ignore
+    except ModuleNotFoundError:
+        pytest.skip("PyYAML not installed")
+
+
+def test_yaml_backend_roundtrip(tmp_path: Path):
+    require_pyyaml()
+    flat = {"x.y": 1, "x.z": True, "name": "Sigil"}
+    path = tmp_path / "t.yaml"
+    YamlBackend().save(path, flat)
+    assert YamlBackend().load(path) == flat
+
+
+def test_empty_file(tmp_path: Path):
+    require_pyyaml()
+    path = tmp_path / "empty.yaml"
+    path.write_text("", encoding="utf-8")
+    assert YamlBackend().load(path) == {}
+
+
+def test_deep_nesting(tmp_path: Path):
+    require_pyyaml()
+    flat = {"a.b.c.d": 2}
+    path = tmp_path / "deep.yml"
+    YamlBackend().save(path, flat)
+    assert YamlBackend().load(path) == flat
+
+
+def test_invalid_yaml(tmp_path: Path):
+    require_pyyaml()
+    path = tmp_path / "bad.yaml"
+    path.write_text("[invalid", encoding="utf-8")
+    with pytest.raises(SigilLoadError):
+        YamlBackend().load(path)


### PR DESCRIPTION
## Summary
- implement `YamlBackend` with optional PyYAML dependency
- register YAML backend
- test YAML backend roundtrip and error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68877df1ed4c832888c34cd8f7dcdbb4