### PR TITLE
Add hub module for package defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ separate project. See `tests/manual_tests/README.md` for more examples.
 
 Typed helper methods are available for convenient access:
 `Sigil.get_int()`, `get_float()`, `get_bool()`.
+For package integration details see [docs/integration.md](docs/integration.md).

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,41 @@
+# Sigil MVP — Package-Author Integration Checklist
+
+(Everything you need to do; everything you automatically get. Nothing more.)
+
+| # | Action you take in your package | Exact snippet / path | What Sigil gives you for free |
+|---|--------------------------------|----------------------|--------------------------------|
+| 1 | Create a defaults file (INI only for MVP) | `mypkg/prefs/defaults.ini`<br><br>```ini
+[db]
+host = localhost
+port = 5432
+``` | Becomes the base layer of the preference chain. |
+| 2 | Declare that file in `pyproject.toml` | ```toml
+[tool.sigil]
+defaults = "prefs/defaults.ini"
+``` | Sigil-Hub auto-discovers your package during import. |
+| 3 | (Optional but recommended) Expose helpers so callers never touch Sigil APIs | ```python
+# mypkg/__init__.py
+from sigil.hub import get_preferences as _gp
+get_pref, set_pref = _gp(__name__)  # __name__ == "mypkg"
+``` | • One-line access:<br>`get_pref("db.host")`<br>• Handles env ▶ project ▶ user ▶ defaults without extra code. |
+| 4 | (Optional) ship metadata later | Add `prefs/defaults.meta.json` and set `meta = "prefs/defaults.meta.json"` under `[tool.sigil]` | When the GUI arrives, titles, tool-tips and “secret” flags will show automatically. No impact on MVP. |
+
+## What you get immediately
+
+Fully merged prefs:
+`SIGIL_MYPKG_DB_HOST (env) → ./settings.ini (project) → ~/.config/mypkg/settings.ini (user) → your defaults.ini.`
+
+No boiler-plate: call `get_pref()` / `set_pref()` from anywhere in your code.
+
+User tooling already works:
+
+```
+sigil get --app mypkg key
+sigil set --app mypkg key value
+```
+
+Files auto-created as needed.
+
+Zero runtime deps: Sigil is pure std-lib + your INI file.
+
+That’s it. Add one defaults file, one `[tool.sigil]` line, (optionally) four helper lines — and your package instantly gains a robust, chain-aware configuration system.

--- a/sigil/hub.py
+++ b/sigil/hub.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import inspect
+import importlib
+import tomllib
+from pathlib import Path
+from threading import Lock
+from typing import Callable
+
+from .core import Sigil
+
+__all__ = ["get_preferences"]
+
+_configs: dict[str, tuple[Path, Path | None]] = {}
+_instances: dict[str, Sigil] = {}
+_lock = Lock()
+
+
+def _find_pyproject(start: Path) -> Path | None:
+    path = start
+    while True:
+        candidate = path / "pyproject.toml"
+        if candidate.exists():
+            return candidate
+        if path.parent == path:
+            return None
+        path = path.parent
+
+
+def _load_config(package: str) -> tuple[Path, Path | None]:
+    if package in _configs:
+        return _configs[package]
+    module = importlib.import_module(package)
+    start = Path(module.__file__).resolve().parent
+    pyproject = _find_pyproject(start)
+    defaults_rel = Path("prefs/defaults.ini")
+    meta_rel: Path | None = None
+    base = start
+    if pyproject:
+        base = pyproject.parent
+        try:
+            with pyproject.open("rb") as fh:
+                data = tomllib.load(fh)
+            section = data.get("tool", {}).get("sigil", {})
+            if isinstance(section, dict):
+                if "defaults" in section:
+                    defaults_rel = Path(section["defaults"])
+                if "meta" in section:
+                    meta_rel = Path(section["meta"])
+        except Exception:
+            pass
+    defaults_path = defaults_rel if defaults_rel.is_absolute() else base / defaults_rel
+    meta_path = None
+    if meta_rel is not None:
+        meta_path = meta_rel if meta_rel.is_absolute() else base / meta_rel
+    _configs[package] = (defaults_path, meta_path)
+    return defaults_path, meta_path
+
+
+def get_preferences(package: str | None = None) -> tuple[Callable, Callable]:
+    if package is None:
+        frame = inspect.stack()[1].frame
+        package = frame.f_globals.get("__name__")
+        del frame
+        if not isinstance(package, str) or not package:
+            raise ValueError("Could not determine caller package; pass package")
+
+    def _lazy() -> Sigil:
+        if package not in _instances:
+            with _lock:
+                if package not in _instances:
+                    defaults_path, meta_path = _load_config(package)
+                    _instances[package] = Sigil(
+                        package, default_path=defaults_path, meta_path=meta_path
+                    )
+        return _instances[package]
+
+    def get_pref(key: str, *, default=None, cast=None):
+        return _lazy().get_pref(key, default=default, cast=cast)
+
+    def set_pref(key: str, value, *, scope="user"):
+        return _lazy().set_pref(key, value, scope=scope)
+
+    return get_pref, set_pref

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import importlib
+
+from sigil import core
+from sigil.hub import get_preferences
+
+
+def test_get_preferences(tmp_path: Path, monkeypatch):
+    root = tmp_path / "proj"
+    pkg = root / "mypkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("")
+    prefs = pkg / "prefs"
+    prefs.mkdir()
+    (prefs / "defaults.ini").write_text("[db]\nhost=localhost\n")
+    (root / "pyproject.toml").write_text(
+        "[tool.sigil]\ndefaults = 'mypkg/prefs/defaults.ini'\n"
+    )
+
+    monkeypatch.setattr(core, "user_config_dir", lambda app: str(tmp_path / app))
+    sys.path.insert(0, str(root))
+    try:
+        get_pref, set_pref = get_preferences("mypkg")
+        assert get_pref("db.host") == "localhost"
+        set_pref("db.host", "remote")
+        assert get_pref("db.host") == "remote"
+    finally:
+        sys.path.pop(0)


### PR DESCRIPTION
## Summary
- implement `sigil.hub.get_preferences` for package integration
- load defaults/meta from `[tool.sigil]` in pyproject
- test hub integration with temporary package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d6c4747e4832884cd3230225766f5