### PR TITLE
Add GUI launch capability to get_preferences

### DIFF
--- a/sigilcraft/hub.py
+++ b/sigilcraft/hub.py
@@ -35,6 +35,11 @@ class GetPref(Protocol):
 class SetPref(Protocol):
     def __call__(self, key: str, value: Any, *, scope: str = "user") -> Any: ...
 
+
+@runtime_checkable
+class LaunchGui(Protocol):
+    def __call__(self) -> None: ...
+
 # ---------------------------------------------------------------------------
 # 2.  Internal helpers
 # ---------------------------------------------------------------------------
@@ -94,10 +99,10 @@ def get_preferences(
     *,
     default_pref_directory: str | None = None,
     settings_filename: str = "settings.ini",
-) -> tuple[GetPref, SetPref]:
+) -> tuple[GetPref, SetPref, LaunchGui]:
     """
-    Resolve and cache a Sigil instance for *package* and return two thin
-    wrappers: `get_pref` and `set_pref`.
+    Resolve and cache a Sigil instance for *package* and return three thin
+    wrappers: `get_pref`, `set_pref`, and `launch_gui`.
 
     Parameters
     ----------
@@ -138,7 +143,14 @@ def get_preferences(
     def set_pref(key: str, value: Any, *, scope: str = "user") -> Any:
         return _lazy().set_pref(key, value, scope=scope)
 
-    return get_pref, set_pref
+    def launch_gui() -> None:
+        """Launch a preferences GUI configured for this package."""
+        from .gui import PrefModel, run
+
+        sigil = _lazy()
+        run(PrefModel(sigil, sigil._meta), f"Sigil Preferences — {sigil.app_name}")
+
+    return get_pref, set_pref, launch_gui
 
 
 # def _find_pyproject(start: Path) -> Path | None:

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,11 +1,32 @@
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
-import importlib
-
-from sigilcraft import core
+from sigilcraft.gui import PrefModel
 from sigilcraft.hub import get_preferences
 
 
+def test_get_preferences_launch_gui(tmp_path, monkeypatch):
+    # Prepare a prefs directory with a defaults file
+    prefs_dir = tmp_path / "prefs"
+    prefs_dir.mkdir()
+    (prefs_dir / "settings.ini").write_text("[global]\ncolor = red\n")
+
+    called: dict[str, object] = {}
+
+    def fake_run(model: PrefModel, title: str) -> None:  # type: ignore[override]
+        called["model"] = model
+        called["title"] = title
+
+    monkeypatch.setattr("sigilcraft.gui.run", fake_run)
+
+    get_pref, set_pref, launch_gui = get_preferences(
+        "sigilcraft", default_pref_directory=str(prefs_dir)
+    )
+
+    assert get_pref("color") == "red"
+
+    launch_gui()
+
+    assert isinstance(called["model"], PrefModel)
+    assert called["title"] == "Sigil Preferences — sigilcraft"


### PR DESCRIPTION
## Summary
- extend `get_preferences` to expose a `launch_gui` callable
- provide test covering GUI launch wrapper

## Testing
- `pytest`
- `pre-commit run --files sigilcraft/hub.py tests/test_hub.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891427940948328a94b6e5b7ccc0187