### PR TITLE
Enable default scope writes and refactor scope handling

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -41,3 +41,30 @@ def test_defaults_from_file(tmp_path: Path):
     defaults.write_text("[ui]\ntheme=light\n")
     s = Sigil("app", default_path=defaults)
     assert s.get_pref("ui.theme") == "light"
+
+
+def test_set_pref_default_scope(tmp_path: Path):
+    defaults = tmp_path / "defaults.ini"
+    s = Sigil("app", default_path=defaults)
+    s.set_pref("ui.theme", "dark", scope="default")
+    s.set_default_scope("default")
+    s.set_pref("color", "red")
+    s2 = Sigil("app", default_path=defaults)
+    assert s2.get_pref("ui.theme") == "dark"
+    assert s2.get_pref("color") == "red"
+
+
+def test_scoped_values_and_default_scope(tmp_path: Path):
+    user_path = tmp_path / "user.ini"
+    project_path = tmp_path / "project.ini"
+    s = Sigil("app", user_scope=user_path, project_scope=project_path, defaults={"color": "red"})
+    s.set_pref("color", "green", scope="user")
+    s.set_pref("shape", "circle", scope="project")
+    all_vals = s.scoped_values()
+    assert all_vals["default"]["color"] == "red"
+    assert all_vals["user"]["color"] == "green"
+    assert all_vals["project"]["shape"] == "circle"
+    s.set_default_scope("project")
+    s.set_pref("size", "large")
+    all_vals2 = s.scoped_values()
+    assert "size" in all_vals2["project"] and "size" not in all_vals2["user"]


### PR DESCRIPTION
## Summary
- allow `default` scope writes by persisting default file path and mapping
- add `_get_scope_storage` for robust scope resolution and extend PrefModel
- verify default-scope persistence with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68914d1f6814832883adc3d7427360eb