### PR TITLE
Ensure consistent settings file across scopes

### DIFF
--- a/sigilcraft/helpers.py
+++ b/sigilcraft/helpers.py
@@ -44,13 +44,19 @@ def make_package_prefs(
     lock = Lock()
     sigil_obj: Sigil | None = None
     defaults_path: Path = resources.files(package).joinpath(defaults_rel)
+    defaults_dir = defaults_path.parent
+    settings_file = defaults_path.name
 
     def _lazy() -> Sigil:
         nonlocal sigil_obj
         if sigil_obj is None:
             with lock:
                 if sigil_obj is None:
-                    sigil_obj = Sigil(app_name, default_path=defaults_path)
+                    sigil_obj = Sigil(
+                        app_name,
+                        default_path=defaults_dir,
+                        settings_filename=settings_file,
+                    )
         return sigil_obj
 
     def _get(key: str, *, default=None, cast=None):

--- a/sigilcraft/hub.py
+++ b/sigilcraft/hub.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import inspect
-import importlib
-import tomllib
 import threading
 from pathlib import Path
 from threading import Lock
@@ -64,7 +62,7 @@ def _load_config(
     settings_filename: str,
 ) -> tuple[Path, Path | None]:
     # ------------------------------------------------------------------
-    # Determine defaults_path (= prefs folder) and metadata path.
+    # Determine defaults directory and optional metadata sidecar.
     # ------------------------------------------------------------------
     if package:
         # Import the package and look at its __file__.
@@ -80,14 +78,14 @@ def _load_config(
         if default_pref_directory is not None
         else project_root / "prefs"
     )
-    defaults_path = prefs_dir / settings_filename
+    defaults_dir = prefs_dir
 
     # Allow optional metadata sidecar (JSON or CSV) but don't require it.
     meta_json = prefs_dir / "metadata.json"
     meta_csv = prefs_dir / "metadata.csv"
     meta_path = meta_json if meta_json.exists() else (meta_csv if meta_csv.exists() else None)
 
-    return defaults_path, meta_path
+    return defaults_dir, meta_path
 
 
 # ---------------------------------------------------------------------------
@@ -120,12 +118,12 @@ def get_preferences(
         if package not in _instances:
             with _lock:
                 if package not in _instances:
-                    defaults_path, meta_path = _load_config(
+                    defaults_dir, meta_path = _load_config(
                         package, default_pref_directory, settings_filename
                     )
                     _instances[package] = Sigil(  # type: ignore[name-defined]
                         app_name=package,
-                        default_path=defaults_path,
+                        default_path=defaults_dir,
                         meta_path=meta_path,
                         settings_filename=settings_filename,
                     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -37,19 +37,19 @@ def test_context_manager_project(tmp_path: Path):
 
 
 def test_defaults_from_file(tmp_path: Path):
-    defaults = tmp_path / "defaults.ini"
-    defaults.write_text("[ui]\ntheme=light\n")
-    s = Sigil("app", default_path=defaults)
+    defaults_dir = tmp_path
+    (defaults_dir / "settings.ini").write_text("[ui]\ntheme=light\n")
+    s = Sigil("app", default_path=defaults_dir)
     assert s.get_pref("ui.theme") == "light"
 
 
 def test_set_pref_default_scope(tmp_path: Path):
-    defaults = tmp_path / "defaults.ini"
-    s = Sigil("app", default_path=defaults)
+    defaults_dir = tmp_path
+    s = Sigil("app", default_path=defaults_dir)
     s.set_pref("ui.theme", "dark", scope="default")
     s.set_default_scope("default")
     s.set_pref("color", "red")
-    s2 = Sigil("app", default_path=defaults)
+    s2 = Sigil("app", default_path=defaults_dir)
     assert s2.get_pref("ui.theme") == "dark"
     assert s2.get_pref("color") == "red"
 


### PR DESCRIPTION
## Summary
- enforce a single settings filename for user, project, and default scopes
- update helper utilities and hub to use the new path resolution
- adjust core tests to pass defaults via directories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892b9c3c930832885a86acae5092c22