### PR TITLE
feat(gui): add scoped tabs

### DIFF
--- a/sigilcraft/gui/model.py
+++ b/sigilcraft/gui/model.py
@@ -52,6 +52,10 @@ class PrefModel:
     def meta(self, key: str) -> Mapping:
         return self._meta.get(key, {})
 
+    def scoped_values(self) -> Mapping[str, MutableMapping[str, str]]:
+        """Return preferences grouped by scope."""
+        return self.sigil.scoped_values()
+
     # ----- write operations -----
     def set(self, key: str, value: Any, scope: str = "user") -> None:
         if scope not in {"user", "project", "default"}:

--- a/sigilcraft/gui/tk_view.py
+++ b/sigilcraft/gui/tk_view.py
@@ -18,6 +18,28 @@ def run(model: PrefModel, app_title: str | None = None) -> None:
     frame.pack(fill="both", expand=True)
     label = ttk.Label(frame, text="Preferences for " + model.sigil.app_name)
     label.pack()
+
+    notebook = ttk.Notebook(frame)
+    notebook.pack(fill="both", expand=True, padx=5, pady=5)
+
+    scope_colors = {
+        "default": "lightgrey",
+        "user": "lightblue",
+        "project": "lightgreen",
+    }
+    scoped = model.scoped_values()
+    for scope in ("default", "user", "project"):
+        prefs = scoped.get(scope, {})
+        tab = tk.Frame(notebook, bg=scope_colors[scope])
+        notebook.add(tab, text=scope.capitalize())
+        for row, (key, value) in enumerate(sorted(prefs.items())):
+            tk.Label(tab, text=key, bg=scope_colors[scope], anchor="w").grid(
+                row=row, column=0, sticky="w", padx=5, pady=2
+            )
+            tk.Label(tab, text=value, bg=scope_colors[scope], anchor="w").grid(
+                row=row, column=1, sticky="w", padx=5, pady=2
+            )
+
     close_btn = ttk.Button(frame, text="Close", command=root.destroy)
     close_btn.pack(pady=10)
     root.mainloop()


### PR DESCRIPTION
## Summary
- display scoped preferences in new Tk GUI tabs
- expose scoped preference values from the PrefModel adapter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892c1d5983883288e09d8eb530b5f87