### PR TITLE
Add GUI v2 event-driven preference editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,12 @@ separate project. See `tests/manual_tests/README.md` for more examples.
 Typed helper methods are available for convenient access:
 `Sigil.get_int()`, `get_float()`, `get_bool()`.
 For package integration details see [docs/integration.md](docs/integration.md).
+
+## Using the GUI
+
+Sigil ships with a simple graphical editor for viewing and editing
+preferences. After installation launch it with:
+
+```bash
+sigil-gui
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["sigilcraft*"]
+include = ["sigilcraft*", "sigil*"]
 exclude = ["appdirs"]
 
 [project]

--- a/sigil/__init__.py
+++ b/sigil/__init__.py
@@ -1,0 +1,1 @@
+"""Additional utilities for Sigil GUI and event handling."""

--- a/sigil/events.py
+++ b/sigil/events.py
@@ -1,0 +1,17 @@
+"""Simple pub-sub event helper for Sigil GUI."""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+_callbacks: dict[str, list[Callable]] = {}
+
+
+def on(event: str, fn: Callable) -> None:
+    """Register *fn* to be called when *event* is emitted."""
+    _callbacks.setdefault(event, []).append(fn)
+
+
+def emit(event: str, *args, **kwargs) -> None:
+    """Emit *event*, calling all subscribed callbacks."""
+    for fn in _callbacks.get(event, []):
+        fn(*args, **kwargs)

--- a/sigil/gui.py
+++ b/sigil/gui.py
@@ -1,0 +1,168 @@
+"""Tk GUI for editing Sigil preferences."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import simpledialog, ttk
+from typing import Literal
+
+from sigilcraft.core import Sigil
+
+from . import events
+from .widgets import widget_for
+
+_sigil_instance: Sigil | None = None
+
+
+def edit_preferences(package: str | None = None, *, allow_default_write: bool = True) -> None:
+    """Launch the preference editor for *package*.
+
+    This function blocks until the window is closed.
+    """
+    global _sigil_instance
+    app = package or "app"
+    _sigil_instance = Sigil(app)
+    root = tk.Tk()
+    root.title(f"Sigil Preferences — {_sigil_instance.app_name}")
+    widgets = _build_main_window(root)
+    for scope, tree in widgets["trees"].items():
+        _populate_tree(tree, scope)
+    events.on("pref_changed", lambda k, v, s: _on_pref_changed(widgets, k, v, s))
+    root.mainloop()
+
+
+def launch_gui() -> None:
+    """Console entry point."""
+    edit_preferences()
+
+
+# ----- helpers -----
+
+def _current_scope(widgets: dict) -> str:
+    nb: ttk.Notebook = widgets["notebook"]
+    tab_id = nb.select()
+    return nb.tab(tab_id, "text").lower()
+
+
+def _build_main_window(root: tk.Tk) -> dict:
+    notebook = ttk.Notebook(root)
+    notebook.pack(fill="both", expand=True)
+    trees: dict[str, ttk.Treeview] = {}
+    for scope in ("default", "user", "project"):
+        frame = ttk.Frame(notebook)
+        tree = ttk.Treeview(frame, columns=("key", "value"), show="headings")
+        tree.heading("key", text="key")
+        tree.heading("value", text="value")
+        tree.pack(fill="both", expand=True)
+        notebook.add(frame, text=scope.title())
+        trees[scope] = tree
+    btn_frame = ttk.Frame(root)
+    btn_frame.pack(fill="x", pady=4)
+    add_btn = ttk.Button(btn_frame, text="Add")
+    edit_btn = ttk.Button(btn_frame, text="Edit")
+    del_btn = ttk.Button(btn_frame, text="Delete")
+    close_btn = ttk.Button(btn_frame, text="Close", command=root.destroy)
+    for btn in (add_btn, edit_btn, del_btn, close_btn):
+        btn.pack(side="left", padx=2)
+    widgets = {
+        "root": root,
+        "notebook": notebook,
+        "trees": trees,
+        "add": add_btn,
+        "edit": edit_btn,
+        "delete": del_btn,
+    }
+    add_btn.configure(command=lambda: _on_add(widgets))
+    edit_btn.configure(command=lambda: _on_edit(widgets))
+    del_btn.configure(command=lambda: _on_delete(widgets))
+    return widgets
+
+
+def _populate_tree(tree: ttk.Treeview, scope: str) -> None:
+    assert _sigil_instance is not None
+    tree.delete(*tree.get_children())
+    values = _sigil_instance.scoped_values().get(scope, {})
+    for key, value in sorted(values.items()):
+        tree.insert("", "end", iid=key, values=(key, value))
+
+
+def _open_value_dialog(
+    mode: Literal["add", "edit"],
+    scope: str,
+    *,
+    key: str = "",
+    value: str = "",
+):
+    parent = tk._get_default_root()
+    title = "Add preference" if mode == "add" else "Edit preference"
+
+    class _Dialog(simpledialog.Dialog):
+        def body(self, master):  # type: ignore[override]
+            ttk.Label(master, text="Key:").grid(row=0, column=0, sticky="w")
+            self.key_w = widget_for("key", None, master)
+            self.key_w.grid(row=0, column=1, padx=5, pady=5)
+            self.key_w.set(key)
+            ttk.Label(master, text="Value:").grid(row=1, column=0, sticky="w")
+            self.val_w = widget_for(key, None, master)
+            self.val_w.grid(row=1, column=1, padx=5, pady=5)
+            self.val_w.set(value)
+            return self.key_w
+
+        def apply(self):  # type: ignore[override]
+            self.result = (self.key_w.get(), self.val_w.get())
+
+    dlg = _Dialog(parent, title)
+    return dlg.result
+
+
+def _on_add(widgets: dict) -> None:
+    scope = _current_scope(widgets)
+    res = _open_value_dialog("add", scope)
+    if not res:
+        return
+    key, value = res
+    assert _sigil_instance is not None
+    _sigil_instance.set_pref(key, value, scope=scope)
+
+
+def _on_edit(widgets: dict) -> None:
+    scope = _current_scope(widgets)
+    tree: ttk.Treeview = widgets["trees"][scope]
+    sel = tree.selection()
+    if not sel:
+        return
+    key = sel[0]
+    current = tree.item(key, "values")[1]
+    res = _open_value_dialog("edit", scope, key=key, value=current)
+    if not res:
+        return
+    new_key, new_val = res
+    assert _sigil_instance is not None
+    if new_key != key:
+        _sigil_instance.set_pref(key, None, scope=scope)
+        key = new_key
+    _sigil_instance.set_pref(key, new_val, scope=scope)
+
+
+def _on_delete(widgets: dict) -> None:
+    scope = _current_scope(widgets)
+    tree: ttk.Treeview = widgets["trees"][scope]
+    sel = tree.selection()
+    if not sel:
+        return
+    key = sel[0]
+    assert _sigil_instance is not None
+    _sigil_instance.set_pref(key, None, scope=scope)
+
+
+def _on_pref_changed(widgets: dict, key: str, new_val: str | None, scope: str) -> None:
+    tree: ttk.Treeview = widgets["trees"].get(scope)
+    if tree is None:
+        return
+    if new_val is None:
+        if tree.exists(key):
+            tree.delete(key)
+    else:
+        if tree.exists(key):
+            tree.item(key, values=(key, new_val))
+        else:
+            tree.insert("", "end", iid=key, values=(key, new_val))

--- a/sigil/widgets.py
+++ b/sigil/widgets.py
@@ -1,0 +1,22 @@
+"""Widget dispatcher stub for Sigil GUI."""
+from __future__ import annotations
+
+from tkinter import StringVar, ttk
+
+
+def widget_for(key: str, meta: dict | None, master):
+    """Return a ready-to-grid Tk widget for editing *key*.
+
+    For version 2 this always returns :class:`ttk.Entry` bound to a
+    :class:`tkinter.StringVar`. The widget exposes ``get()`` and ``set()``
+    methods for retrieving and updating the value.
+    """
+
+    var = StringVar(master)
+    entry = ttk.Entry(master, textvariable=var)
+
+    def set_value(value: str) -> None:
+        var.set(value)
+
+    entry.set = set_value  # type: ignore[attr-defined]
+    return entry

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sigil import events, gui
+from sigilcraft.core import Sigil
+
+
+class DummyTree:
+    def __init__(self) -> None:
+        self.rows: dict[str, tuple[str, str]] = {}
+        self._selection: list[str] = []
+
+    def insert(self, parent, index, iid, values):
+        self.rows[iid] = values
+
+    def item(self, iid, option=None, **kwargs):
+        if kwargs:
+            self.rows[iid] = kwargs.get("values", self.rows[iid])
+            return
+        if option == "values":
+            return self.rows[iid]
+        return {"values": self.rows[iid]}
+
+    def delete(self, *iids):
+        for iid in iids:
+            self.rows.pop(iid, None)
+
+    def exists(self, iid):
+        return iid in self.rows
+
+    def selection(self):
+        return tuple(self._selection)
+
+    def selection_set(self, iid):
+        self._selection = [iid]
+
+    def get_children(self):
+        return list(self.rows)
+
+
+class DummyNotebook:
+    def __init__(self, current: str) -> None:
+        self._current = current
+
+    def select(self, tab=None):
+        if tab is None:
+            return self._current
+        self._current = tab
+
+    def tab(self, tab_id, option=None):
+        if option == "text":
+            return tab_id.capitalize()
+        return ""
+
+
+def make_widgets(current_scope: str):
+    nb = DummyNotebook(current_scope)
+    trees = {scope: DummyTree() for scope in ("default", "user", "project")}
+    return {"notebook": nb, "trees": trees}
+
+
+def setup_func(tmp_path: Path) -> tuple[Sigil, dict]:
+    events._callbacks.clear()  # type: ignore[attr-defined]
+    sig = Sigil(
+        "app",
+        user_scope=tmp_path / "u.ini",
+        project_scope=tmp_path / "p.ini",
+    )
+    gui._sigil_instance = sig
+    widgets = make_widgets("user")
+    events.on("pref_changed", lambda k, v, s: gui._on_pref_changed(widgets, k, v, s))
+    return sig, widgets
+
+
+def test_add(monkeypatch, tmp_path):
+    sig, widgets = setup_func(tmp_path)
+    monkeypatch.setattr(gui, "_open_value_dialog", lambda *a, **k: ("color", "blue"))
+    gui._on_add(widgets)
+    assert sig.get_pref("color") == "blue"
+    assert widgets["trees"]["user"].rows["color"][1] == "blue"
+
+
+def test_edit(monkeypatch, tmp_path):
+    sig, widgets = setup_func(tmp_path)
+    sig.set_pref("color", "blue", scope="user")
+    gui._populate_tree(widgets["trees"]["user"], "user")
+    widgets["trees"]["user"].selection_set("color")
+    monkeypatch.setattr(gui, "_open_value_dialog", lambda *a, **k: ("color", "green"))
+    gui._on_edit(widgets)
+    assert sig.get_pref("color") == "green"
+    assert widgets["trees"]["user"].rows["color"][1] == "green"
+
+
+def test_delete(tmp_path):
+    sig, widgets = setup_func(tmp_path)
+    sig.set_pref("color", "blue", scope="user")
+    gui._populate_tree(widgets["trees"]["user"], "user")
+    widgets["trees"]["user"].selection_set("color")
+    gui._on_delete(widgets)
+    assert sig.get_pref("color") is None
+    assert "color" not in widgets["trees"]["user"].rows


### PR DESCRIPTION
## Summary
- add GUI v2 module exposing Add/Edit/Delete workflows
- provide widgets stub and event bus for preference changes
- emit events from core set_pref and document GUI usage
- remove broken GUI screenshot asset

## Testing
- `python -m ruff check sigil/events.py sigil/widgets.py sigil/gui.py sigilcraft/core.py tests/test_gui_logic.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893d9782d88832899fc9c7db13f1ca0