### PR TITLE
Fix imports after sigilcraft rename and simplify GUI layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["sigilcraft*", "sigil*"]
+include = ["sigilcraft*"]
 exclude = ["appdirs"]
 
 [project]
@@ -20,8 +20,8 @@ secrets = ["keyring>=25"]
 secrets-crypto = ["keyring>=25", "cryptography>=42"]
 
 [project.scripts]
-sigil = "sigil.cli:main"
-sigil-gui = "sigil.gui:launch_gui"
+sigil = "sigilcraft.cli:main"
+sigil-gui = "sigilcraft.gui:launch_gui"
 
 [tool.ruff]
 line-length = 88

--- a/sigilcraft/core.py
+++ b/sigilcraft/core.py
@@ -13,7 +13,7 @@ try:
 except ModuleNotFoundError:
     from ._appdirs_stub import user_config_dir
 
-import events
+from . import events
 
 from .backend import get_backend_for_path
 from .env import read_env

--- a/sigilcraft/gui/__init__.py
+++ b/sigilcraft/gui/__init__.py
@@ -1,22 +1,20 @@
-"""ttk-based Preferences GUI."""
+"""Tk GUI and models for editing Sigil preferences."""
 
-from __future__ import annotations
-
+from . import editor as _editor
 from .model import PrefModel
 from .tk_view import run
 
+_sigil_instance = None
 
-def launch_gui(app_name: str) -> None:
-    """Entry point used by the ``sigil-gui`` console script."""
-    from ..core import Sigil
-    from ..helpers import load_meta
+edit_preferences = _editor.edit_preferences
+launch_gui = _editor.launch_gui
+_build_main_window = _editor._build_main_window
+_current_scope = _editor._current_scope
+_on_add = _editor._on_add
+_on_delete = _editor._on_delete
+_on_edit = _editor._on_edit
+_on_pref_changed = _editor._on_pref_changed
+_open_value_dialog = _editor._open_value_dialog
+_populate_tree = _editor._populate_tree
 
-    sigil = Sigil(app_name)
-    meta_path = sigil.user_path.parent / "defaults.meta.csv"
-    try:
-        meta = load_meta(meta_path)
-    except Exception:
-        meta = {}
-    run(PrefModel(sigil, meta), f"Sigil Preferences — {app_name}")
-
-__all__ = ["launch_gui", "PrefModel", "run"]
+__all__ = ["PrefModel", "run", "edit_preferences", "launch_gui"]


### PR DESCRIPTION
## Summary
- fix core imports to use sigilcraft modules
- consolidate GUI into package and expose helpers
- refactor GUI package to keep initializer minimal by moving editor logic into a dedicated module

## Testing
- `pytest`
- `pre-commit run --files sigilcraft/gui/__init__.py sigilcraft/gui/editor.py` *(fails: command not found; attempted `pip install pre-commit` but could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6893e07838448328add5916e866d50cc