### PR TITLE
Ensure custom Sigil config is used when launching GUI

### DIFF
--- a/sigilcraft/gui/editor.py
+++ b/sigilcraft/gui/editor.py
@@ -14,14 +14,22 @@ def _gui() -> object:
     return import_module("sigilcraft.gui")
 
 
-def edit_preferences(package: str | None = None, *, allow_default_write: bool = True) -> None:
-    """Launch the preference editor for *package*.
+def edit_preferences(
+    package: str | None = None,
+    *,
+    allow_default_write: bool = True,
+    sigil: Sigil | None = None,
+) -> None:
+    """Launch the preference editor for *package* or provided ``sigil`` instance.
 
     This function blocks until the window is closed.
     """
     gui = _gui()
-    app = package or "app"
-    gui._sigil_instance = Sigil(app)
+    if sigil is None:
+        app = package or "app"
+        gui._sigil_instance = Sigil(app)
+    else:
+        gui._sigil_instance = sigil
     root = tk.Tk()
     root.title(f"Sigil Preferences — {gui._sigil_instance.app_name}")
     widgets = _build_main_window(root)
@@ -31,9 +39,18 @@ def edit_preferences(package: str | None = None, *, allow_default_write: bool = 
     root.mainloop()
 
 
-def launch_gui() -> None:
-    """Console entry point."""
-    edit_preferences()
+def launch_gui(
+    package: str | None = None,
+    *,
+    allow_default_write: bool = True,
+    sigil: Sigil | None = None,
+) -> None:
+    """Console entry point for the editor GUI."""
+    edit_preferences(
+        package,
+        allow_default_write=allow_default_write,
+        sigil=sigil,
+    )
 
 
 # ----- helpers -----

--- a/sigilcraft/hub.py
+++ b/sigilcraft/hub.py
@@ -143,8 +143,11 @@ def get_preferences(
 
     def launch_gui() -> None:
         """Launch a preferences GUI configured for this package."""
-        from .gui import PrefModel, run
+        from .gui import launch_gui as _launch
+
         sigil = _lazy()
-        run(PrefModel(sigil, sigil._meta), f"Sigil Preferences — {sigil.app_name}")
+        # Pass the resolved Sigil instance so that the editor reflects the
+        # caller's package-specific defaults and metadata.
+        _launch(sigil=sigil)
 
     return get_pref, set_pref, launch_gui

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sigilcraft.gui import PrefModel
+from sigilcraft.core import Sigil
 from sigilcraft.hub import get_preferences
 
 
@@ -14,11 +14,10 @@ def test_get_preferences_launch_gui(tmp_path, monkeypatch):
 
     called: dict[str, object] = {}
 
-    def fake_run(model: PrefModel, title: str) -> None:  # type: ignore[override]
-        called["model"] = model
-        called["title"] = title
+    def fake_launch(*, package=None, allow_default_write=True, sigil=None):
+        called["sigil"] = sigil
 
-    monkeypatch.setattr("sigilcraft.gui.run", fake_run)
+    monkeypatch.setattr("sigilcraft.gui.launch_gui", fake_launch)
 
     get_pref, set_pref, launch_gui = get_preferences(
         "sigilcraft", default_pref_directory=str(prefs_dir)
@@ -28,5 +27,5 @@ def test_get_preferences_launch_gui(tmp_path, monkeypatch):
 
     launch_gui()
 
-    assert isinstance(called["model"], PrefModel)
-    assert called["title"] == "Sigil Preferences — sigilcraft"
+    assert isinstance(called["sigil"], Sigil)
+    assert called["sigil"].app_name == "sigilcraft"


### PR DESCRIPTION
## Summary
- allow `edit_preferences`/`launch_gui` to accept a prebuilt Sigil instance
- forward the Sigil object from `get_preferences` to the GUI launcher
- adjust tests to check that the resolved Sigil instance is passed to the GUI

## Testing
- `pre-commit run --files sigilcraft/gui/editor.py sigilcraft/hub.py tests/test_hub.py` *(fails: command not found; attempted to install but pip could not find pre-commit)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893e5b9b878832887bc4925f164c0fe