### PR TITLE
Implement tuple-based KeyPath parsing and storage

### DIFF
--- a/sigilcraft/__init__.py
+++ b/sigilcraft/__init__.py
@@ -3,8 +3,17 @@ from __future__ import annotations
 
 from .core import Sigil
 from .helpers import make_package_prefs
+from .keys import KeyPath, parse_key
 
-__all__ = ["Sigil", "make_package_prefs", "get_int", "get_float", "get_bool"]
+__all__ = [
+    "Sigil",
+    "make_package_prefs",
+    "get_int",
+    "get_float",
+    "get_bool",
+    "parse_key",
+    "KeyPath",
+]
 __version__ = "0.1.1"
 
 

--- a/sigilcraft/backend/base.py
+++ b/sigilcraft/backend/base.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
 
+from ..keys import KeyPath
+
 
 class BaseBackend(ABC):
     """Abstract base backend."""
@@ -11,9 +13,9 @@ class BaseBackend(ABC):
     suffixes: tuple[str, ...] = ()
 
     @abstractmethod
-    def load(self, path: Path) -> MutableMapping[str, MutableMapping[str, str]]:
+    def load(self, path: Path) -> MutableMapping[KeyPath, str]:
         pass
 
     @abstractmethod
-    def save(self, path: Path, data: Mapping[str, Mapping[str, str]]) -> None:
+    def save(self, path: Path, data: Mapping[KeyPath, str]) -> None:
         pass

--- a/sigilcraft/backend/json_backend.py
+++ b/sigilcraft/backend/json_backend.py
@@ -5,29 +5,28 @@ from collections.abc import Mapping, MutableMapping
 from pathlib import Path
 
 from ..errors import SigilLoadError
+from ..keys import KeyPath
 from . import register_backend
 from .base import BaseBackend
 
 
-def _flatten(src: Mapping[str, object], prefix: str = "") -> MutableMapping[str, object]:
-    out: MutableMapping[str, object] = {}
+def _collect(src: Mapping[str, object], prefix: tuple[str, ...] = ()) -> MutableMapping[KeyPath, str]:
+    out: MutableMapping[KeyPath, str] = {}
     for k, v in src.items():
-        key = f"{prefix}{k}" if not prefix else f"{prefix}.{k}"
         if isinstance(v, dict):
-            out.update(_flatten(v, key))
+            out.update(_collect(v, prefix + (k,)))
         else:
-            out[key] = v
+            out[prefix + (k,)] = str(v)
     return out
 
 
-def _unflatten(flat: Mapping[str, object]) -> dict:
+def _build(flat: Mapping[KeyPath, str]) -> dict:
     root: dict = {}
-    for dotted, val in flat.items():
-        parts = dotted.split(".")
+    for path, val in flat.items():
         node = root
-        for p in parts[:-1]:
+        for p in path[:-1]:
             node = node.setdefault(p, {})
-        node[parts[-1]] = val
+        node[path[-1]] = val
     return root
 
 
@@ -46,7 +45,7 @@ class JsonBackend(BaseBackend):
                 pass
         return json.loads(text)
 
-    def load(self, path: Path) -> MutableMapping[str, object]:
+    def load(self, path: Path) -> MutableMapping[KeyPath, str]:
         path = Path(path)
         if not path.exists():
             return {}
@@ -59,11 +58,11 @@ class JsonBackend(BaseBackend):
             raise SigilLoadError(str(exc)) from exc
         if not isinstance(data, dict):
             raise SigilLoadError("Root of JSON prefs must be an object")
-        return _flatten(data)
+        return _collect(data)
 
-    def save(self, path: Path, data: Mapping[str, object]) -> None:
+    def save(self, path: Path, data: Mapping[KeyPath, str]) -> None:
         path = Path(path)
-        nested = _unflatten(data)
+        nested = _build(data)
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(path.suffix + ".tmp")
         with tmp.open("w", encoding="utf-8") as fh:

--- a/sigilcraft/env.py
+++ b/sigilcraft/env.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import os
 from collections.abc import MutableMapping
 
+from .keys import KeyPath, parse_key
 
-def read_env(app_name: str) -> MutableMapping[str, str]:
+
+def read_env(app_name: str) -> MutableMapping[KeyPath, str]:
     prefix = f"SIGIL_{app_name.upper()}_"
-    result: MutableMapping[str, str] = {}
+    result: MutableMapping[KeyPath, str] = {}
     for key, value in os.environ.items():
         if key.startswith(prefix):
-            path = key[len(prefix):].lower().replace("_", ".")
-            result[path] = value
+            raw = key[len(prefix):].lower()
+            result[parse_key(raw)] = value
     return result

--- a/sigilcraft/keys.py
+++ b/sigilcraft/keys.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import re
+
+KeyPath = tuple[str, ...]
+
+
+def parse_key(raw: str | KeyPath, delims: str | None = None) -> KeyPath:
+    """Parse *raw* into a canonical ``KeyPath``.
+
+    ``delims`` is a string containing single-character delimiters. If
+    ``None``, ``"._"`` is used. An empty string disables splitting.
+    """
+    if isinstance(raw, tuple):
+        return raw
+    delims = "._" if delims is None else delims
+    if not delims:
+        return (raw,)
+    pattern = "[" + re.escape(delims) + "]"
+    parts = re.split(pattern, raw)
+    if any(p == "" for p in parts):
+        raise ValueError(
+            f"Malformed key '{raw}' (consecutive/edge delimiter)"
+        )
+    return tuple(parts)

--- a/tests/test_backend_ini.py
+++ b/tests/test_backend_ini.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 
 from sigilcraft.backend.ini_backend import IniBackend
+from sigilcraft.keys import KeyPath
 
 
 def test_ini_backend_roundtrip(tmp_path: Path):
     path = tmp_path / "cfg.ini"
     backend = IniBackend()
-    data = {"global": {"a": "1"}, "sec": {"b": "2"}}
+    data = {("a",): "1", ("sec", "b"): "2", ("sec", "deep", "c"): "3"}
     backend.save(path, data)
     loaded = backend.load(path)
     assert loaded == data

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -6,4 +6,4 @@ from sigilcraft.env import read_env
 def test_read_env(monkeypatch):
     monkeypatch.setenv("SIGIL_MYAPP_FOO_BAR", "baz")
     result = read_env("myapp")
-    assert result == {"foo.bar": "baz"}
+    assert result == {("foo", "bar"): "baz"}

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -10,7 +10,7 @@ def test_get_preferences_launch_gui(tmp_path, monkeypatch):
     # Prepare a prefs directory with a defaults file
     prefs_dir = tmp_path / "prefs"
     prefs_dir.mkdir()
-    (prefs_dir / "settings.ini").write_text("[global]\ncolor = red\n")
+    (prefs_dir / "settings.ini").write_text("[__root__]\ncolor = red\n")
 
     called: dict[str, object] = {}
 

--- a/tests/test_json_backend.py
+++ b/tests/test_json_backend.py
@@ -9,7 +9,7 @@ from sigilcraft.errors import SigilLoadError
 
 
 def test_json_backend_roundtrip(tmp_path: Path):
-    flat = {"x.y": 1, "x.z": True, "name": "Sigil"}
+    flat = {("x", "y"): "1", ("x", "z"): "true", ("name",): "Sigil"}
     path = tmp_path / "t.json"
     JsonBackend().save(path, flat)
     assert JsonBackend().load(path) == flat
@@ -22,7 +22,7 @@ def test_empty_file(tmp_path: Path):
 
 
 def test_deep_nesting(tmp_path: Path):
-    flat = {"a.b.c.d": 2}
+    flat = {("a", "b", "c", "d"): "2"}
     path = tmp_path / "deep.json"
     JsonBackend().save(path, flat)
     assert JsonBackend().load(path) == flat
@@ -42,5 +42,5 @@ def test_json5_relaxed(tmp_path: Path):
         pytest.skip("pyjson5 not installed")
     path = tmp_path / "relaxed.json5"
     path.write_text("//c\n{a:1,}\n", encoding="utf-8")
-    assert JsonBackend().load(path) == {"a": 1}
+    assert JsonBackend().load(path) == {("a",): "1"}
 

--- a/tests/test_parse_key.py
+++ b/tests/test_parse_key.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+from sigilcraft.keys import parse_key
+
+
+def test_parse_key_default():
+    assert parse_key("a_b.c") == ("a", "b", "c")
+
+
+def test_parse_key_custom_delim():
+    assert parse_key("a-b-c", delims="-") == ("a", "b", "c")
+
+
+def test_parse_key_no_delim():
+    assert parse_key("a-b", delims="") == ("a-b",)
+
+
+def test_parse_key_malformed():
+    with pytest.raises(ValueError):
+        parse_key(".a")
+    with pytest.raises(ValueError):
+        parse_key("a..b")
+    with pytest.raises(ValueError):
+        parse_key("a.")

--- a/tests/test_yaml_backend.py
+++ b/tests/test_yaml_backend.py
@@ -15,7 +15,7 @@ def require_pyyaml():
 
 def test_yaml_backend_roundtrip(tmp_path: Path):
     require_pyyaml()
-    flat = {"x.y": 1, "x.z": True, "name": "Sigil"}
+    flat = {("x", "y"): "1", ("x", "z"): "true", ("name",): "Sigil"}
     path = tmp_path / "t.yaml"
     YamlBackend().save(path, flat)
     assert YamlBackend().load(path) == flat
@@ -30,7 +30,7 @@ def test_empty_file(tmp_path: Path):
 
 def test_deep_nesting(tmp_path: Path):
     require_pyyaml()
-    flat = {"a.b.c.d": 2}
+    flat = {("a", "b", "c", "d"): "2"}
     path = tmp_path / "deep.yml"
     YamlBackend().save(path, flat)
     assert YamlBackend().load(path) == flat


### PR DESCRIPTION
## Summary
- Introduce `parse_key` for canonical tuple-based KeyPath parsing with configurable single-character delimiters
- Refactor Sigil core and storage backends to use KeyPath internally, including new INI `__root__` section handling
- Add comprehensive tests for key parsing and backend round-trips

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689518909eb08328a29e84d7e09f78a2