### PR TITLE
Fix underscore keys displaying as dotted in GUI

### DIFF
--- a/sigilcraft/core.py
+++ b/sigilcraft/core.py
@@ -314,11 +314,12 @@ class Sigil:
             raise ReadOnlyScopeError("Core defaults are read-only")
         path = parse_key(key)
         dotted = ".".join(path)
+        event_key = KEY_JOIN_CHAR.join(path)
         if dotted.startswith("secret.") or self._meta_secret(path):
             if not self._secrets.can_write():
                 raise SigilWriteError("Secrets backend is read-only or locked")
             self._secrets.set(dotted, str(value))
-            events.emit("pref_changed", dotted, value, scope or self._default_scope)
+            events.emit("pref_changed", event_key, value, scope or self._default_scope)
             return
         data, path_file = self._get_scope_storage(target_scope)
         with self._lock:
@@ -329,7 +330,7 @@ class Sigil:
             backend = get_backend_for_path(path_file)
             backend.save(path_file, data)
             self.invalidate_cache()
-        events.emit("pref_changed", dotted, value, target_scope)
+        events.emit("pref_changed", event_key, value, target_scope)
 
     def _get_scope_storage(self, scope: str) -> tuple[MutableMapping[KeyPath, str], Path]:
         if scope == "user":

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -81,6 +81,15 @@ def test_add(monkeypatch, tmp_path):
     assert widgets["trees"]["user"].rows["color"][1] == "blue"
 
 
+def test_add_with_underscore(monkeypatch, tmp_path):
+    sig, widgets = setup_func(tmp_path)
+    monkeypatch.setattr(gui, "_open_value_dialog", lambda *a, **k: ("foo_bar", "baz"))
+    gui._on_add(widgets)
+    assert sig.get_pref("foo_bar") == "baz"
+    assert "foo_bar" in widgets["trees"]["user"].rows
+    assert "foo.bar" not in widgets["trees"]["user"].rows
+
+
 def test_edit(monkeypatch, tmp_path):
     sig, widgets = setup_func(tmp_path)
     sig.set_pref("color", "blue", scope="user")


### PR DESCRIPTION
## Summary
- ensure preference change events use Sigil's key separator so new underscore keys display correctly
- cover underscore key in GUI logic tests

## Testing
- `pytest`
- `pre-commit run --files sigilcraft/core.py tests/test_gui_logic.py` *(fails: command not found: pre-commit)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_68953d7be01083288bc65f5cc8a3d000