### PR TITLE
feat: expose dual CLI entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,19 @@ Preference management for small apps.
 
 ## Quick start
 
-Install pysigil in a virtual environment to make the `sigil` command available:
+Install pysigil in a virtual environment to make the `sigil` and `pysigil` commands available:
 
 ```bash
 python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\Activate
 pip install -e .  # or `pip install .` for a normal install
+```
+
+```bash
+sigil --help
+# or
+pysigil --help
+# or
+python -m pysigil --help
 ```
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ secrets-crypto = ["keyring>=25", "cryptography>=42"]
 
 [project.scripts]
 sigil = "pysigil.cli:main"
+pysigil = "pysigil.cli:main"
 sigil-gui = "pysigil.gui:launch_gui"
 
 [tool.ruff]

--- a/src/pysigil/__main__.py
+++ b/src/pysigil/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 
 from .core import Sigil
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="sigil")
+def build_parser(prog: str = "sigil") -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog)
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     get_p = sub.add_parser("get")
@@ -45,7 +46,11 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = build_parser()
+    argv = sys.argv[1:] if argv is None else argv
+    prog = os.path.basename(sys.argv[0]) or "sigil"
+    if prog == "__main__.py":
+        prog = "pysigil"
+    parser = build_parser(prog)
     args = parser.parse_args(argv)
     sigil = Sigil(args.app)
     if args.cmd == "get":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,8 @@
 
 
+import subprocess
+import sys
+
 from pysigil import cli, core
 
 
@@ -52,3 +55,15 @@ def test_cli_secret_set_get(tmp_path, monkeypatch, capsys):
     assert cli.main(["secret", "get", "token", "--app", "myapp", "--reveal"]) == 0
     revealed = capsys.readouterr().out.strip()
     assert revealed == "abc"
+
+
+def test_cli_help_aliases():
+    sigil_help = cli.build_parser(prog="sigil").format_help()
+    pysigil_help = cli.build_parser(prog="pysigil").format_help()
+    assert sigil_help.replace("sigil", "CMD") == pysigil_help.replace("pysigil", "CMD")
+
+
+def test_module_entry_point_help():
+    proc = subprocess.run([sys.executable, "-m", "pysigil", "--help"], capture_output=True, text=True)
+    assert proc.returncode == 0
+    assert "usage: pysigil" in proc.stdout


### PR DESCRIPTION
## Summary
- expose both `sigil` and `pysigil` console scripts
- add module entry point so `python -m pysigil` works
- document and test all CLI entry options

## Testing
- `pytest`
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_689554dcaaa883288184b9f7fe9f7bf4