### PR TITLE
feat: add per-key policy and locks

### DIFF
--- a/src/pysigil/hub.py
+++ b/src/pysigil/hub.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Protocol, runtime_checkable
 #from pyprojroot import here
 
 from .core import Sigil
-from .keys import parse_key
+from .keys import KeyPath, parse_key
 
 __all__ = ["get_preferences", "parse_key"]
 
@@ -142,6 +142,9 @@ def get_preferences(
     def set_pref(key: str, value: Any, *, scope: str = "user") -> Any:
         return _lazy().set_pref(key, value, scope=scope)
 
+    def effective_scope_for(key: str | KeyPath) -> str:
+        return _lazy().effective_scope_for(key)
+
     def launch_gui() -> None:
         """Launch a preferences GUI configured for this package."""
         from .gui import launch_gui as _launch
@@ -151,4 +154,4 @@ def get_preferences(
         # caller's package-specific defaults and metadata.
         _launch(sigil=sigil)
 
-    return get_pref, set_pref, launch_gui
+    return get_pref, set_pref, effective_scope_for, launch_gui

--- a/src/pysigil/metadata.py
+++ b/src/pysigil/metadata.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .keys import KeyPath
+
+_META: dict[str, dict[str, Any]] = {}
+
+
+def _parse_bool(val: Any) -> bool:
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        v = val.strip().lower()
+        if v in {"1", "true", "y", "yes", "on"}:
+            return True
+        if v in {"0", "false", "n", "no", "off"}:
+                return False
+    return bool(val)
+
+
+def load(path: Path | None) -> None:
+    """Load metadata from *path* applying defaults for policy/locked."""
+    global _META
+    _META = {}
+    if path is None:
+        return
+    from .helpers import load_meta as _load_meta
+
+    raw = _load_meta(Path(path))
+    for key, entry in raw.items():
+        data = dict(entry)
+        policy = data.get("policy", "project_over_user")
+        if policy not in {"project_over_user", "user_over_project"}:
+            policy = "project_over_user"
+        data["policy"] = policy
+        locked = _parse_bool(data.get("locked", False))
+        data["locked"] = locked
+        _META[key] = data
+
+
+def get_meta_for(keypath: KeyPath) -> dict[str, Any]:
+    dotted = ".".join(keypath)
+    data = dict(_META.get(dotted, {}))
+    if "policy" not in data:
+        data["policy"] = "project_over_user"
+    if "locked" not in data:
+        data["locked"] = False
+    return data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from pysigil import cli, core
 
 def test_cli_set_and_get(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(core, "user_config_dir", lambda app: str(tmp_path))
+    monkeypatch.chdir(tmp_path)
     assert cli.main(["set", "color", "blue", "--app", "myapp"]) == 0
     capsys.readouterr()
     assert cli.main(["get", "color", "--app", "myapp"]) == 0

--- a/tests/test_cli_where.py
+++ b/tests/test_cli_where.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pysigil import cli, core
+
+
+def test_cli_where(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(core, "user_config_dir", lambda app: str(tmp_path))
+    # Seed values
+    assert cli.main(["set", "color", "red", "--app", "myapp", "--scope", "project"]) == 0
+    capsys.readouterr()
+    assert cli.main(["set", "color", "blue", "--app", "myapp"]) == 0
+    capsys.readouterr()
+    assert cli.main(["where", "color", "--app", "myapp"]) == 0
+    out = capsys.readouterr().out
+    assert "Policy: project_over_user" in out
+    assert "(locked: false)" in out.lower()
+    assert "project:" in out and "\u2190 effective" in out

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -19,7 +19,7 @@ def test_get_preferences_launch_gui(tmp_path, monkeypatch):
 
     monkeypatch.setattr("pysigil.gui.launch_gui", fake_launch)
 
-    get_pref, set_pref, launch_gui = get_preferences(
+    get_pref, set_pref, effective_scope_for, launch_gui = get_preferences(
         "pysigil", default_pref_directory=str(prefs_dir)
     )
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from pysigil.core import Sigil, LockedPreferenceError
+from pysigil.keys import parse_key
+
+
+def make_sigil(tmp_path, meta_csv: str | None = None, env: dict | None = None) -> Sigil:
+    user = tmp_path / "user.ini"
+    project = tmp_path / "proj.ini"
+    meta_path = None
+    if meta_csv is not None:
+        meta_path = tmp_path / "meta.csv"
+        meta_path.write_text(meta_csv)
+    def reader(_app: str):
+        return env or {}
+    return Sigil(
+        "app",
+        user_scope=user,
+        project_scope=project,
+        meta_path=meta_path,
+        env_reader=reader,
+    )
+
+
+def test_default_policy_project_wins(tmp_path):
+    sig = make_sigil(tmp_path)
+    sig.set_pref("x", 1, scope="project")
+    sig.set_pref("x", 2, scope="user")
+    assert sig.get_pref("x") == 1
+
+
+def test_user_policy_user_wins(tmp_path):
+    meta = "key,policy,locked\nx,user_over_project,false\n"
+    sig = make_sigil(tmp_path, meta)
+    sig.set_pref("x", 1, scope="project")
+    sig.set_pref("x", 2, scope="user")
+    assert sig.get_pref("x") == 2
+
+
+def test_locked_prevents_user_writes(tmp_path):
+    meta = "key,policy,locked\nx,project_over_user,true\n"
+    sig = make_sigil(tmp_path, meta)
+    sig.set_pref("x", 1, scope="project")
+    with pytest.raises(LockedPreferenceError):
+        sig.set_pref("x", 2, scope="user")
+    assert sig.get_pref("x") == 1
+
+
+def test_env_always_wins(tmp_path):
+    env = {parse_key("x"): "3"}
+    sig = make_sigil(tmp_path, env=env)
+    sig.set_pref("x", 1, scope="project")
+    sig.set_pref("x", 2, scope="user")
+    assert sig.get_pref("x") == 3


### PR DESCRIPTION
## Summary
- support per-key precedence policies with optional user locks
- add `sigil where` diagnostic subcommand
- expose effective scope helper and update hub accessors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896652cf8008328b680e2ed89aa1c6b