### PR TITLE
Fix GUI not displaying data for newly selected packages

### DIFF
--- a/src/pysigil/gui.py
+++ b/src/pysigil/gui.py
@@ -48,7 +48,12 @@ def open_package(package: str, include_sigil: bool) -> None:
     global _sigil_instance, _current_package
     logger.debug("opening package %s include_sigil=%s", package, include_sigil)
     try:
-        hub.get_preferences(package)
+        get_pref, *_ = hub.get_preferences(package)
+        # Force instantiation of the package-specific Sigil by performing a
+        # harmless lookup.  ``get_preferences`` creates the instance lazily, so
+        # without this call ``hub._instances`` would remain empty and the GUI
+        # would show no values for newly selected packages.
+        get_pref("__sigil_gui_init__", default=None)
         _sigil_instance = hub._instances.get(package)  # type: ignore[attr-defined]
         logger.debug("loaded instance for %s via hub", package)
     except Exception as exc:

--- a/src/pysigil/hub.py
+++ b/src/pysigil/hub.py
@@ -116,6 +116,13 @@ def get_preferences(
     """
 
     def _lazy() -> "Sigil":
+        # When a custom defaults directory or settings filename is provided we
+        # need to recreate any cached instance for *package* so that callers can
+        # override these paths in tests or specialised environments.
+        if default_pref_directory is not None or settings_filename != "settings.ini":
+            with _lock:
+                _instances.pop(package, None)
+
         if package not in _instances:
             with _lock:
                 if package not in _instances:


### PR DESCRIPTION
## Summary
- ensure GUI forces hub to instantiate package-specific Sigil instances so package data shows up
- allow get_preferences to recreate cached instances when custom defaults are supplied

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68978d7781688328a60c4bc1af7218dd