### PR TITLE
Add default INI backends to orchestrator

### DIFF
--- a/src/pysigil/orchestrator.py
+++ b/src/pysigil/orchestrator.py
@@ -18,6 +18,8 @@ from .authoring import normalize_provider_id
 from .settings_metadata import (
     FieldSpec,
     FieldValue,
+    IniFileBackend,
+    IniSpecBackend,
     ProviderManager,
     ProviderSpec,
     SigilBackend,
@@ -61,7 +63,21 @@ class PolicyError(OrchestratorError):
 class Orchestrator:
     """High level façade coordinating spec and config backends."""
 
-    def __init__(self, spec_backend: SpecBackend, config_backend: SigilBackend):
+    def __init__(
+        self,
+        spec_backend: SpecBackend | None = None,
+        config_backend: SigilBackend | None = None,
+        *,
+        user_dir: Path | None = None,
+        project_dir: Path | None = None,
+        host: str | None = None,
+    ) -> None:
+        if spec_backend is None:
+            spec_backend = IniSpecBackend(base_dir=user_dir)
+        if config_backend is None:
+            config_backend = IniFileBackend(
+                user_dir=user_dir, project_dir=project_dir, host=host
+            )
         self.spec_backend = spec_backend
         self.config_backend = config_backend
 

--- a/tests/manual_orchestrator.py
+++ b/tests/manual_orchestrator.py
@@ -10,7 +10,6 @@ from tempfile import TemporaryDirectory
 
 from pysigil.orchestrator import Orchestrator
 from pysigil.paths import user_config_dir
-from pysigil.settings_metadata import InMemorySpecBackend, IniFileBackend
 
 
 def manual_demo() -> None:
@@ -19,13 +18,11 @@ def manual_demo() -> None:
     user_dir = user_config_dir("sigil")
     with TemporaryDirectory() as tmp:
         project_dir = Path(tmp) / "proj"
-        backend = IniFileBackend(
+        orch = Orchestrator(
             user_dir=user_dir,
             project_dir=project_dir,
             host="host",
         )
-        spec_backend = InMemorySpecBackend()
-        orch = Orchestrator(spec_backend, backend)
 
         # Register a provider (project) and add three fields
         orch.register_provider("demo", title="Demo Project")
@@ -49,7 +46,7 @@ def manual_demo() -> None:
 
         # Edit the provider itself
         orch.edit_provider("demo", title="Demo Project Updated")
-        spec = spec_backend.get_spec("demo")
+        spec = orch.spec_backend.get_spec("demo")
         print("Updated provider title:", spec.title)
 
         user_file = user_dir / "demo" / "settings.ini"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -5,17 +5,14 @@ from pathlib import Path
 import pytest
 
 from pysigil.orchestrator import Orchestrator, ValidationError
-from pysigil.settings_metadata import InMemorySpecBackend, IniFileBackend
 
 
 def _make_orch(tmp_path: Path) -> Orchestrator:
-    backend = IniFileBackend(
+    return Orchestrator(
         user_dir=tmp_path / "user",
         project_dir=tmp_path / "proj",
         host="host",
     )
-    spec_backend = InMemorySpecBackend()
-    return Orchestrator(spec_backend, backend)
 
 
 def test_register_add_set_get(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add `IniSpecBackend` to persist provider specs in INI files
- default orchestrator to built-in INI backends for spec and config storage
- update tests and manual demo for new defaults

## Testing
- `pytest`
- ❌ `pre-commit run --files src/pysigil/settings_metadata.py src/pysigil/orchestrator.py tests/test_orchestrator.py tests/manual_orchestrator.py` (pre-commit: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a7a8246a3c83289a3d4203ad40beef