### PR TITLE
feat: add framework-agnostic ui core and tk skeleton

### DIFF
--- a/src/pysigil/ui/__init__.py
+++ b/src/pysigil/ui/__init__.py
@@ -1,0 +1,11 @@
+"""User interface helpers for pysigil.
+
+This package contains a framework agnostic core layer and optional
+front-end implementations.  The initial implementation uses tkinter
+but the design allows the view layer to be swapped out with minimal
+changes to the core logic.
+"""
+
+from __future__ import annotations
+
+__all__ = ["core", "tk", "widgets"]

--- a/src/pysigil/ui/core.py
+++ b/src/pysigil/ui/core.py
@@ -1,0 +1,263 @@
+"""Framework agnostic GUI core.
+
+The :mod:`pysigil.ui.core` module exposes the minimal pieces required to
+build a graphical user interface on top of :mod:`pysigil.api`.  The code
+here purposefully knows nothing about any widget toolkit; instead it is
+responsible for keeping track of application state, delegating all heavy
+lifting to :mod:`pysigil.api` and notifying interested parties about
+state changes via a tiny callback based event system.
+
+The intention is that concrete front-ends – for instance a tkinter based
+one – bind to the callbacks exposed here.  Replacing the front-end should
+only require reimplementing the view layer while this module can be
+reused unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Literal, Protocol
+from concurrent.futures import ThreadPoolExecutor, Future
+import threading
+
+from .. import api
+
+# ---------------------------------------------------------------------------
+# Application state
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class AppState:
+    """In-memory representation of the UI state."""
+
+    provider_id: str | None = None
+    provider_info: api.ProviderInfo | None = None
+    fields: list[api.FieldInfo] = field(default_factory=list)
+    values: Dict[str, api.ValueInfo] = field(default_factory=dict)
+    active_tab: Literal["overview", "user", "project"] = "overview"
+    is_dirty_spec: bool = False
+    is_dirty_values: bool = False
+    project_detected: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Event handling
+# ---------------------------------------------------------------------------
+
+
+class EventBus:
+    """Simple callback based pub/sub system."""
+
+    def __init__(self) -> None:
+        self.on_state_changed: list[Callable[[AppState], None]] = []
+        self.on_error: list[Callable[[str], None]] = []
+        self.on_toast: list[Callable[[str, str], None]] = []
+        self.on_confirm: list[Callable[[str, str], bool]] = []
+        self.on_progress: list[Callable[[bool], None]] = []
+
+    # Emit helpers -----------------------------------------------------
+    def emit_state(self, state: AppState) -> None:
+        for cb in list(self.on_state_changed):
+            cb(state)
+
+    def emit_error(self, msg: str) -> None:
+        for cb in list(self.on_error):
+            cb(msg)
+
+    def emit_toast(self, msg: str, level: str = "info") -> None:
+        for cb in list(self.on_toast):
+            cb(msg, level)
+
+    def emit_progress(self, started: bool) -> None:
+        for cb in list(self.on_progress):
+            cb(started)
+
+
+# ---------------------------------------------------------------------------
+# Service façade (thin wrapper over :mod:`pysigil.api`)
+# ---------------------------------------------------------------------------
+
+
+class ProvidersService:
+    """Lightweight façade over :mod:`pysigil.api`.
+
+    The service performs no caching; callers are expected to cache data in
+    :class:`AppState` if necessary.
+    """
+
+    def list_providers(self) -> list[str]:
+        return api.providers()
+
+    def select_provider(self, pid: str) -> api.ProviderInfo:
+        return api.get_provider(pid)
+
+    def get_fields(self, pid: str) -> list[api.FieldInfo]:
+        return api.handle(pid).fields()
+
+    def get_effective(self, pid: str) -> Dict[str, api.ValueInfo]:
+        return api.handle(pid).effective()
+
+    def add_field(
+        self,
+        pid: str,
+        key: str,
+        type: str,
+        *,
+        label: str | None = None,
+        description: str | None = None,
+        init_scope: Literal["user", "project"] | None = "user",
+    ) -> api.FieldInfo:
+        return api.handle(pid).add_field(
+            key,
+            type,
+            label=label,
+            description=description,
+            init_scope=init_scope,
+        )
+
+    def set_value(
+        self,
+        pid: str,
+        key: str,
+        value: Any,
+        *,
+        scope: Literal["user", "project"] = "user",
+    ) -> None:
+        api.handle(pid).set(key, value, scope=scope)
+
+    def clear_value(
+        self,
+        pid: str,
+        key: str,
+        *,
+        scope: Literal["user", "project"] = "user",
+    ) -> None:
+        api.handle(pid).clear(key, scope=scope)
+
+    def init(self, pid: str, scope: Literal["user", "project"]) -> None:
+        api.handle(pid).init(scope)
+
+    def export_spec(self, pid: str) -> None:  # pragma: no cover - thin pass through
+        api.handle(pid).export_spec()
+
+    def reload_spec(self, pid: str) -> api.ProviderInfo:
+        return api.handle(pid).info()
+
+
+# ---------------------------------------------------------------------------
+# App core / command helpers
+# ---------------------------------------------------------------------------
+
+
+class AppCore:
+    """Mediator between the view and :class:`ProvidersService`.
+
+    It keeps the current :class:`AppState` and exposes a small selection of
+    command methods which operate on the service.  All operations involving
+    the service are executed in a thread pool in order to avoid blocking the
+    UI thread in front-ends such as tkinter.
+    """
+
+    def __init__(
+        self,
+        service: ProvidersService | None = None,
+        *,
+        executor: ThreadPoolExecutor | None = None,
+    ) -> None:
+        self.state = AppState()
+        self.service = service or ProvidersService()
+        self.events = EventBus()
+        self._executor = executor or ThreadPoolExecutor(max_workers=4)
+        self._lock = threading.Lock()
+
+    # --- concurrency -------------------------------------------------
+    def run_async(self, fn: Callable[[], Any]) -> Future[Any]:
+        """Run ``fn`` in the thread pool and return the future."""
+
+        def runner() -> Any:
+            try:
+                self.events.emit_progress(True)
+                return fn()
+            finally:
+                self.events.emit_progress(False)
+
+        return self._executor.submit(runner)
+
+    # --- commands ----------------------------------------------------
+    def select_provider(self, pid: str) -> Future[None]:
+        """Load provider metadata and effective values."""
+
+        def _task() -> None:
+            info = self.service.select_provider(pid)
+            fields = self.service.get_fields(pid)
+            values = self.service.get_effective(pid)
+            with self._lock:
+                self.state.provider_id = pid
+                self.state.provider_info = info
+                self.state.fields = fields
+                self.state.values = values
+            self.events.emit_state(self.state)
+
+        return self.run_async(_task)
+
+    def refresh(self) -> Future[None]:
+        """Refresh fields and values for the current provider."""
+
+        pid = self.state.provider_id
+        if pid is None:  # nothing to do
+            future: Future[None] = Future()
+            future.set_result(None)
+            return future
+
+        def _task() -> None:
+            info = self.service.reload_spec(pid)
+            fields = self.service.get_fields(pid)
+            values = self.service.get_effective(pid)
+            with self._lock:
+                self.state.provider_info = info
+                self.state.fields = fields
+                self.state.values = values
+            self.events.emit_state(self.state)
+
+        return self.run_async(_task)
+
+    def save_value(
+        self, key: str, value: Any, *, scope: Literal["user", "project"] = "user"
+    ) -> Future[None]:
+        pid = self.state.provider_id
+        if pid is None:
+            raise RuntimeError("no provider selected")
+
+        def _task() -> None:
+            self.service.set_value(pid, key, value, scope=scope)
+            val = self.service.get_effective(pid).get(key)
+            if val is not None:
+                with self._lock:
+                    self.state.values[key] = val
+            self.events.emit_state(self.state)
+
+        return self.run_async(_task)
+
+    def clear_value(
+        self, key: str, *, scope: Literal["user", "project"] = "user"
+    ) -> Future[None]:
+        pid = self.state.provider_id
+        if pid is None:
+            raise RuntimeError("no provider selected")
+
+        def _task() -> None:
+            self.service.clear_value(pid, key, scope=scope)
+            with self._lock:
+                self.state.values.pop(key, None)
+            self.events.emit_state(self.state)
+
+        return self.run_async(_task)
+
+
+__all__ = [
+    "AppCore",
+    "AppState",
+    "EventBus",
+    "ProvidersService",
+]

--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -1,0 +1,78 @@
+"""Tkinter based view layer for :mod:`pysigil.ui`.
+
+The classes in this module provide a very small concrete implementation of
+:class:`pysigil.ui.core.AppCore` using tkinter.  The goal of the module is
+not to offer a feature complete GUI but rather to demonstrate how a view
+layer can be wired to the framework agnostic core.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Literal, Protocol
+
+try:  # pragma: no cover - importing tkinter is environment dependent
+    import tkinter as tk
+    from tkinter import messagebox
+except Exception:  # pragma: no cover - fallback when tkinter missing
+    tk = None  # type: ignore
+    messagebox = None  # type: ignore
+
+from ..core import AppCore, AppState
+
+
+class ViewAdapter(Protocol):
+    """Minimal protocol expected by :class:`AppCore` front-ends."""
+
+    def bind_state(self, callback: Callable[[AppState], None]) -> None: ...
+    def show_toast(self, msg: str, level: Literal["info", "warn", "error"]) -> None: ...
+    def confirm(self, title: str, msg: str) -> bool: ...
+    def prompt_new_field(self): ...
+
+
+class TkApp:
+    """Very small tkinter application shell.
+
+    The application only exposes enough functionality for unit tests and
+    for developers experimenting with the new architecture.  A more
+    full-featured GUI can be built incrementally on top of this skeleton.
+    """
+
+    def __init__(self, core: AppCore | None = None) -> None:
+        if tk is None:  # pragma: no cover - tkinter not available
+            raise RuntimeError("tkinter is required for TkApp")
+        self.core = core or AppCore()
+        self.root = tk.Tk()
+        self.root.title("pysigil")
+        self._state_cb: Callable[[AppState], None] | None = None
+        # forward state changes to bound callback
+        self.core.events.on_state_changed.append(self._dispatch_state)
+
+    # -- view adapter protocol ---------------------------------------
+    def bind_state(self, callback: Callable[[AppState], None]) -> None:
+        self._state_cb = callback
+
+    def show_toast(self, msg: str, level: Literal["info", "warn", "error"] = "info") -> None:
+        if messagebox is None:  # pragma: no cover - tkinter missing
+            return
+        if level == "error":
+            messagebox.showerror("pysigil", msg)
+        elif level == "warn":
+            messagebox.showwarning("pysigil", msg)
+        else:
+            messagebox.showinfo("pysigil", msg)
+
+    def confirm(self, title: str, msg: str) -> bool:
+        if messagebox is None:  # pragma: no cover
+            return False
+        return bool(messagebox.askyesno(title, msg))
+
+    def prompt_new_field(self):  # pragma: no cover - placeholder dialog
+        return None
+
+    # -- internal helpers --------------------------------------------
+    def _dispatch_state(self, state: AppState) -> None:
+        if self._state_cb is not None:
+            self._state_cb(state)
+
+
+__all__ = ["TkApp", "ViewAdapter"]

--- a/src/pysigil/ui/widgets.py
+++ b/src/pysigil/ui/widgets.py
@@ -1,0 +1,95 @@
+"""Widget registry for basic field editors.
+
+The registry maps a field ``type`` as reported by :mod:`pysigil.api` to a
+callable returning an editor widget.  Editors follow a very small
+protocol which makes it straightforward to provide alternative
+implementations for other GUI toolkits.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Protocol, Dict, Any
+
+try:  # pragma: no cover - importing tkinter is environment dependent
+    import tkinter as tk
+    from tkinter import ttk
+except Exception:  # pragma: no cover - fallback when tkinter missing
+    tk = None  # type: ignore
+    ttk = None  # type: ignore
+
+
+class EditorWidget(Protocol):
+    """Protocol all editor widgets must implement."""
+
+    def get_value(self) -> object | None: ...
+    def set_value(self, value: object | None) -> None: ...
+    def set_error(self, msg: str | None) -> None: ...
+    def set_source_badge(self, source: str | None) -> None: ...
+
+
+# -- concrete editor implementations ---------------------------------------
+
+
+def _simple_entry(master) -> EditorWidget:
+    if tk is None or ttk is None:  # pragma: no cover - tkinter missing
+        raise RuntimeError("tkinter is required for widgets")
+    entry = ttk.Entry(master)
+
+    def get_value() -> object | None:
+        text = entry.get()
+        return text if text != "" else None
+
+    def set_value(value: object | None) -> None:
+        entry.delete(0, tk.END)
+        if value is not None:
+            entry.insert(0, str(value))
+
+    def set_error(msg: str | None) -> None:
+        if msg:
+            entry.configure(foreground="red")
+        else:
+            entry.configure(foreground="black")
+
+    def set_source_badge(_src: str | None) -> None:  # pragma: no cover - placeholder
+        pass
+
+    entry.get_value = get_value  # type: ignore[attr-defined]
+    entry.set_value = set_value  # type: ignore[attr-defined]
+    entry.set_error = set_error  # type: ignore[attr-defined]
+    entry.set_source_badge = set_source_badge  # type: ignore[attr-defined]
+    return entry  # type: ignore[return-value]
+
+
+def _boolean_check(master) -> EditorWidget:
+    if tk is None or ttk is None:  # pragma: no cover - tkinter missing
+        raise RuntimeError("tkinter is required for widgets")
+    var = tk.BooleanVar()
+    widget = ttk.Checkbutton(master, variable=var)
+
+    def get_value() -> object | None:
+        return var.get()
+
+    def set_value(value: object | None) -> None:
+        var.set(bool(value))
+
+    def set_error(_msg: str | None) -> None:  # pragma: no cover - placeholder
+        pass
+
+    def set_source_badge(_src: str | None) -> None:  # pragma: no cover - placeholder
+        pass
+
+    widget.get_value = get_value  # type: ignore[attr-defined]
+    widget.set_value = set_value  # type: ignore[attr-defined]
+    widget.set_error = set_error  # type: ignore[attr-defined]
+    widget.set_source_badge = set_source_badge  # type: ignore[attr-defined]
+    return widget  # type: ignore[return-value]
+
+
+FIELD_WIDGETS: Dict[str, Callable[[Any], EditorWidget]] = {
+    "string": _simple_entry,
+    "integer": _simple_entry,
+    "number": _simple_entry,
+    "boolean": _boolean_check,
+}
+
+__all__ = ["EditorWidget", "FIELD_WIDGETS"]


### PR DESCRIPTION
## Summary
- add AppState, ProvidersService, and AppCore to support toolkit-agnostic GUIs
- introduce registry-driven widget editors and basic Tk view adapter

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/ui/__init__.py src/pysigil/ui/core.py src/pysigil/ui/widgets.py src/pysigil/ui/tk/__init__.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ff40660c8328b07fd9b175dffdbd