### PR TITLE
feat(gui): extend core and tk app

### DIFF
--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -48,15 +48,66 @@ class TkApp:
         self.root.title("pysigil")
         self._state_cb: Callable[[AppState], None] | None = None
 
-        # provider selector -------------------------------------------------
+        # provider selector and context header ----------------------------
+        header = ttk.Frame(self.root)
+        header.pack(fill="x", padx=5, pady=5)
         providers = self.core.service.list_providers()
         self._provider_var = tk.StringVar()
         self._provider_box = ttk.Combobox(
-            self.root, textvariable=self._provider_var, state="readonly"
+            header, textvariable=self._provider_var, state="readonly"
         )
         self._provider_box["values"] = providers
         self._provider_box.bind("<<ComboboxSelected>>", self._on_provider_selected)
-        self._provider_box.pack(fill="x", padx=5, pady=5)
+        self._provider_box.pack(side="left")
+
+        self._scope_var = tk.StringVar(value=self.core.state.active_scope)
+        ttk.Radiobutton(
+            header,
+            text="User",
+            variable=self._scope_var,
+            value="user",
+            command=self._on_scope_changed,
+        ).pack(side="left", padx=4)
+        ttk.Radiobutton(
+            header,
+            text="Project",
+            variable=self._scope_var,
+            value="project",
+            command=self._on_scope_changed,
+        ).pack(side="left", padx=4)
+
+        self._host_label = ttk.Label(header, text=f"Host: {self.core.state.host_id}")
+        self._host_label.pack(side="left", padx=4)
+        self._proj_label = ttk.Label(header, text="No project detected")
+        self._proj_label.pack(side="left", padx=4)
+
+        btns = ttk.Frame(header)
+        btns.pack(side="right")
+        ttk.Button(
+            btns,
+            text="New setting",
+            command=lambda: self.prompt_new_field(),
+        ).pack(side="left", padx=2)
+        ttk.Button(
+            btns,
+            text="Init",
+            command=lambda: self.core.init_scope(self._scope_var.get()),
+        ).pack(side="left", padx=2)
+        ttk.Button(
+            btns,
+            text="Open folder",
+            command=lambda: self.core.open_folder(self._scope_var.get()),
+        ).pack(side="left", padx=2)
+        ttk.Button(
+            btns,
+            text="Open file",
+            command=lambda: self.core.open_file(self._scope_var.get()),
+        ).pack(side="left", padx=2)
+        ttk.Button(
+            btns,
+            text="Add .gitignore",
+            command=self.core.add_gitignore,
+        ).pack(side="left", padx=2)
 
         # container for field editors --------------------------------------
         self._fields_frame = ttk.Frame(self.root)
@@ -65,6 +116,14 @@ class TkApp:
         # forward state changes to bound callback and local UI
         self.core.events.on_state_changed.append(self._dispatch_state)
         self.core.events.on_state_changed.append(self._on_state)
+        self.core.events.on_toast.append(self._on_toast)
+        self.core.events.on_error.append(lambda msg: self._on_toast(msg, "error"))
+
+        # keyboard shortcuts ----------------------------------------------
+        self.root.bind("/", lambda e: self._provider_box.focus_set())
+        self.root.bind("<F5>", lambda e: self.core.refresh())
+        self.root.bind("<Control-n>", lambda e: self.prompt_new_field())
+        self.root.bind("<Control-s>", lambda e: self.core.refresh())
 
     # -- view adapter protocol ---------------------------------------
     def bind_state(self, callback: Callable[[AppState], None]) -> None:
@@ -104,17 +163,45 @@ class TkApp:
             return
         for child in self._fields_frame.winfo_children():
             child.destroy()
+        self._scope_var.set(state.active_scope)
+        if state.project_root is not None:
+            self._proj_label.configure(text=str(state.project_root))
+        else:
+            self._proj_label.configure(text="No project detected")
+        self._host_label.configure(text=f"Host: {state.host_id}")
         for field in state.fields:
-            label = ttk.Label(
-                self._fields_frame, text=field.label or field.key, anchor="w"
+            row = ttk.Frame(self._fields_frame)
+            row.pack(fill="x", padx=5, pady=2)
+            ttk.Label(row, text=field.label or field.key, anchor="w", width=20).pack(
+                side="left"
             )
-            label.pack(fill="x", padx=5, pady=2)
             factory = FIELD_WIDGETS.get(field.type, FIELD_WIDGETS["string"])
-            editor = factory(self._fields_frame)
+            editor = factory(row)
             val = state.values.get(field.key)
             if val is not None:
                 editor.set_value(val.value)
-            editor.pack(fill="x", padx=5, pady=2)
+                editor.set_source_badge(val.source)
+            editor.pack(side="left", fill="x", expand=True, padx=5)
+            ttk.Button(
+                row,
+                text="Save",
+                command=lambda k=field.key, e=editor: self.core.save_value(
+                    k, e.get_value(), scope=self._scope_var.get()
+                ),
+            ).pack(side="left", padx=2)
+            ttk.Button(
+                row,
+                text="Clear",
+                command=lambda k=field.key: self.core.clear_value(
+                    k, scope=self._scope_var.get()
+                ),
+            ).pack(side="left", padx=2)
+
+    def _on_scope_changed(self) -> None:
+        self.core.set_active_scope(self._scope_var.get())
+
+    def _on_toast(self, msg: str, level: str) -> None:
+        self.show_toast(msg, level)
 
 
 __all__ = ["TkApp", "ViewAdapter"]

--- a/src/pysigil/ui/widgets.py
+++ b/src/pysigil/ui/widgets.py
@@ -33,7 +33,11 @@ class EditorWidget(Protocol):
 def _simple_entry(master) -> EditorWidget:
     if tk is None or ttk is None:  # pragma: no cover - tkinter missing
         raise RuntimeError("tkinter is required for widgets")
-    entry = ttk.Entry(master)
+    frame = ttk.Frame(master)
+    entry = ttk.Entry(frame)
+    entry.pack(side="left", fill="x", expand=True)
+    badge = ttk.Label(frame, text="")
+    badge.pack(side="left", padx=4)
 
     def get_value() -> object | None:
         text = entry.get()
@@ -50,21 +54,25 @@ def _simple_entry(master) -> EditorWidget:
         else:
             entry.configure(foreground="black")
 
-    def set_source_badge(_src: str | None) -> None:  # pragma: no cover - placeholder
-        pass
+    def set_source_badge(src: str | None) -> None:
+        badge.configure(text=src or "")
 
-    entry.get_value = get_value  # type: ignore[attr-defined]
-    entry.set_value = set_value  # type: ignore[attr-defined]
-    entry.set_error = set_error  # type: ignore[attr-defined]
-    entry.set_source_badge = set_source_badge  # type: ignore[attr-defined]
-    return entry  # type: ignore[return-value]
+    frame.get_value = get_value  # type: ignore[attr-defined]
+    frame.set_value = set_value  # type: ignore[attr-defined]
+    frame.set_error = set_error  # type: ignore[attr-defined]
+    frame.set_source_badge = set_source_badge  # type: ignore[attr-defined]
+    return frame  # type: ignore[return-value]
 
 
 def _boolean_check(master) -> EditorWidget:
     if tk is None or ttk is None:  # pragma: no cover - tkinter missing
         raise RuntimeError("tkinter is required for widgets")
+    frame = ttk.Frame(master)
     var = tk.BooleanVar()
-    widget = ttk.Checkbutton(master, variable=var)
+    widget = ttk.Checkbutton(frame, variable=var)
+    widget.pack(side="left")
+    badge = ttk.Label(frame, text="")
+    badge.pack(side="left", padx=4)
 
     def get_value() -> object | None:
         return var.get()
@@ -75,14 +83,14 @@ def _boolean_check(master) -> EditorWidget:
     def set_error(_msg: str | None) -> None:  # pragma: no cover - placeholder
         pass
 
-    def set_source_badge(_src: str | None) -> None:  # pragma: no cover - placeholder
-        pass
+    def set_source_badge(src: str | None) -> None:
+        badge.configure(text=src or "")
 
-    widget.get_value = get_value  # type: ignore[attr-defined]
-    widget.set_value = set_value  # type: ignore[attr-defined]
-    widget.set_error = set_error  # type: ignore[attr-defined]
-    widget.set_source_badge = set_source_badge  # type: ignore[attr-defined]
-    return widget  # type: ignore[return-value]
+    frame.get_value = get_value  # type: ignore[attr-defined]
+    frame.set_value = set_value  # type: ignore[attr-defined]
+    frame.set_error = set_error  # type: ignore[attr-defined]
+    frame.set_source_badge = set_source_badge  # type: ignore[attr-defined]
+    return frame  # type: ignore[return-value]
 
 
 FIELD_WIDGETS: Dict[str, Callable[[Any], EditorWidget]] = {


### PR DESCRIPTION
## Summary
- expose additional provider management helpers in UI core
- improve Tk-based GUI with context header, scope controls and per-row actions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa08f4bdf88328b727364c93b79dd8