### PR TITLE
feat(gui): redesign settings editor with explicit scopes

### DIFF
--- a/src/pysigil/api.py
+++ b/src/pysigil/api.py
@@ -17,6 +17,7 @@ from .errors import (
     ValidationError,
 )
 from .orchestrator import Orchestrator
+from .config import target_path as cfg_target_path
 from .settings_metadata import FieldSpec, FieldValue, ProviderSpec
 
 __all__ = [
@@ -318,3 +319,7 @@ class ProviderHandle:
     def reload_spec(self) -> ProviderInfo:
         spec = _ORCH.reload_spec(self.provider_id)
         return _provider_info(spec)
+
+    def target_path(self, scope: Literal["user", "project"] = "user") -> Path:
+        """Return the file path used for *scope* writes."""
+        return cfg_target_path(self.provider_id, scope)

--- a/src/pysigil/config.py
+++ b/src/pysigil/config.py
@@ -138,6 +138,21 @@ def init_config(provider_id: str, scope: str, *, auto: bool = False) -> Path:
     return path
 
 
+def target_path(provider_id: str, scope: str, *, auto: bool = False) -> Path:
+    """Return the configuration file path for *provider_id* and *scope*.
+
+    Unlike :func:`init_config` this does not seed the file with any content;
+    it merely returns the path where settings would be written.  Directories
+    are created as needed so the returned path is always usable for writes.
+    """
+    pid = normalize_provider_id(provider_id)
+    h = host_id()
+    base = _scope_dir(scope, pid, auto=auto)
+    if pid == "user-custom":
+        return base / f"settings-local-{h}.ini"
+    return base / "settings.ini"
+
+
 def open_scope(provider_id: str, scope: str, *, auto: bool = False) -> Path:
     return _scope_dir(scope, provider_id, auto=auto)
 

--- a/src/pysigil/core.py
+++ b/src/pysigil/core.py
@@ -381,6 +381,21 @@ class Sigil:
                     return scope
         return "none"
 
+    def path_for_scope(self, scope: str) -> Path:
+        """Return the path backing *scope*.
+
+        This helper exposes the location that will be written to when a value
+        is saved in the given *scope*.  It is primarily intended for user
+        interfaces that need to communicate the write target clearly.
+        """
+        if scope == "user":
+            return self.user_path
+        if scope == "project":
+            return self.project_path
+        if scope == "default" and self.default_path is not None:
+            return self.default_path
+        raise UnknownScopeError(scope)
+
     def set_pref(self, key: str | KeyPath, value: Any, *, scope: str | None = None) -> None:
         target_scope = scope or self._default_scope
         if target_scope == "core":


### PR DESCRIPTION
## Summary
- expose config file paths via new `path_for_scope` and `target_path` helpers
- overhaul Tk GUI to show scope selection, write target and per-key values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa186f9dac8328a2e84d45cfffa0b8