### PR TITLE
Add layer inspection and scope menu builder

### DIFF
--- a/src/pysigil/api.py
+++ b/src/pysigil/api.py
@@ -247,6 +247,17 @@ class ProviderHandle:
         values = _ORCH.get_effective(self.provider_id)
         return {k: _value_info(v) for k, v in values.items()}
 
+    def layers(self) -> dict[str, dict[str, ValueInfo | None]]:
+        """Return values for all scopes for this provider."""
+        layers = _ORCH.get_layers(self.provider_id)
+        result: dict[str, dict[str, ValueInfo | None]] = {}
+        for key, per_scope in layers.items():
+            result[key] = {
+                scope: (_value_info(v) if v is not None else None)
+                for scope, v in per_scope.items()
+            }
+        return result
+
     def get(self, key: str) -> ValueInfo:
         eff = self.effective()
         if key not in eff:

--- a/src/pysigil/orchestrator.py
+++ b/src/pysigil/orchestrator.py
@@ -388,6 +388,10 @@ class Orchestrator:
         """
         return self._manager(provider_id).effective()
 
+    def get_layers(self, provider_id: str) -> dict[str, dict[str, FieldValue | None]]:
+        """Return values for all scopes for *provider_id*."""
+        return self._manager(provider_id).layers()
+
     def set_value(
         self,
         provider_id: str,

--- a/src/pysigil/ui/core.py
+++ b/src/pysigil/ui/core.py
@@ -102,6 +102,9 @@ class ProvidersService:
     def get_effective(self, pid: str) -> Dict[str, api.ValueInfo]:
         return api.handle(pid).effective()
 
+    def get_layers(self, pid: str) -> Dict[str, Dict[str, api.ValueInfo | None]]:
+        return api.handle(pid).layers()
+
     def add_field(
         self,
         pid: str,

--- a/src/pysigil/ui/scope_menu.py
+++ b/src/pysigil/ui/scope_menu.py
@@ -1,0 +1,102 @@
+"""Build per-row scope menu data structures.
+
+This module contains a small helper that translates the specification for
+the per-row scope dropdown into a framework agnostic representation.  The
+resulting list can be consumed by concrete UI toolkits to render the menu
+and wire callbacks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List
+
+from .. import api
+
+
+@dataclass
+class Action:
+    label: str
+    enabled: bool = True
+    handler: Callable[[], Any] | None = None
+
+
+@dataclass
+class ScopeRow:
+    scope: str
+    effective: bool = False
+    present: bool = False
+    actions: List[Action] = field(default_factory=list)
+
+    def add(self, action: Action) -> None:
+        self.actions.append(action)
+
+
+@dataclass
+class Separator:
+    pass
+
+
+def build_menu(
+    handle: api.ProviderHandle,
+    key: str,
+    active_scope: str,
+    policy,
+) -> List[object]:
+    """Return a list describing the per-row scope menu.
+
+    The returned list contains :class:`Action`, :class:`ScopeRow` and
+    :class:`Separator` instances as described in the specification.  Concrete
+    view layers can interpret this structure to render the dropdown.
+    """
+
+    eff = handle.effective().get(key)
+    layers = handle.layers().get(key, {})
+    paths = {
+        scope: handle.target_path(scope)
+        for scope in ("user", "user-local", "project", "project-local")
+    }
+
+    def has(scope: str) -> bool:
+        return layers.get(scope) is not None
+
+    def writable(scope: str) -> bool:
+        allows = getattr(policy, "allows", lambda s: True)
+        return bool(allows(scope))
+
+    menu: List[object] = []
+
+    # Quick actions
+    menu.append(Action(f"Edit at {active_scope}", enabled=writable(active_scope)))
+    same_as_eff = has(active_scope) and eff is not None and layers[active_scope].value == eff.value
+    copy_enabled = writable(active_scope) and eff is not None and eff.value is not None and not same_as_eff
+    menu.append(
+        Action(
+            f"Copy effective here ({active_scope})",
+            enabled=copy_enabled,
+        )
+    )
+    menu.append(Separator())
+
+    # Scopes list
+    for scope in ["user", "user-local", "project", "project-local"]:
+        row = ScopeRow(scope, effective=(eff is not None and eff.source == scope), present=has(scope))
+        if has(scope):
+            row.add(Action("Edit…", enabled=writable(scope)))
+            row.add(Action("Remove", enabled=writable(scope)))
+        else:
+            row.add(Action("Add…", enabled=writable(scope)))
+        menu.append(row)
+
+    menu.append(Separator())
+    menu.append(Action("Show layers…"))
+
+    # Files
+    for scope in ["user", "project", "user-local", "project-local"]:
+        menu.append(Action(f"Open file for {scope}", enabled=paths.get(scope) is not None))
+
+    return menu
+
+
+__all__ = ["Action", "ScopeRow", "Separator", "build_menu"]
+


### PR DESCRIPTION
## Summary
- expose per-scope `layers` data in ProviderHandle and backends
- add framework-agnostic helper to construct per-row scope dropdown menus

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa23d04ca08328ac1fbe2e938d47f2