### PR TITLE
refactor: relocate config GUI

### DIFF
--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -131,7 +131,7 @@ def config_gitignore(args: argparse.Namespace) -> int:
 
 
 def config_gui(_: argparse.Namespace) -> int:  # pragma: no cover - GUI interactions
-    from .gui import launch_config_gui
+    from .ui.tk.config_gui import launch as launch_config_gui
 
     launch_config_gui()
     return 0

--- a/src/pysigil/gui/__init__.py
+++ b/src/pysigil/gui/__init__.py
@@ -19,7 +19,7 @@ except Exception:  # pragma: no cover - fallback for headless tests
 from ..config import available_providers, init_config
 from ..merge_policy import KeyPath
 from . import events, gui_state
-from .config_gui import launch as launch_config_gui
+from ..ui.tk.config_gui import launch as launch_config_gui
 from .widgets import widget_for
 
 if TYPE_CHECKING:

--- a/src/pysigil/ui/tk/config_gui.py
+++ b/src/pysigil/ui/tk/config_gui.py
@@ -7,7 +7,7 @@ import tkinter as tk
 from pathlib import Path
 from tkinter import messagebox, ttk
 
-from ..config import host_id, init_config, open_scope
+from ...config import host_id, init_config, open_scope
 
 
 def _launch(path: Path) -> None:  # pragma: no cover - best effort


### PR DESCRIPTION
## Summary
- move configuration GUI to `ui/tk`
- update CLI and gui module to import new path

## Testing
- `pytest -q`
- `pre-commit run --files src/pysigil/cli.py src/pysigil/gui/__init__.py src/pysigil/ui/tk/config_gui.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b5d4a888388328841f3aaaebb9d232