### PR TITLE
Add minimum option for integer settings

### DIFF
--- a/src/pysigil/settings_metadata.py
+++ b/src/pysigil/settings_metadata.py
@@ -103,6 +103,14 @@ class IntegerAdapter:
     def validate(self, value: Any, spec: FieldSpec) -> None:
         if value is not None and not isinstance(value, int):
             raise TypeError("expected int")
+        if value is None:
+            return
+        minimum = spec.options.get("minimum")
+        if minimum is not None:
+            if not isinstance(minimum, int):
+                raise TypeError("minimum option must be int")
+            if value < minimum:
+                raise ValueError(f"value {value} < minimum {minimum}")
 
 
 class NumberAdapter:
@@ -165,6 +173,14 @@ class StringListAdapter:
         ):
             raise TypeError("expected list[str]")
 
+
+@dataclass
+class IntegerOptions:
+    """Configuration options for integer fields."""
+
+    minimum: int | None = None
+
+
 @dataclass(frozen=True)
 class FieldType:
     """Metadata describing a supported field type."""
@@ -177,7 +193,7 @@ class FieldType:
 
 TYPE_REGISTRY: dict[str, FieldType] = {
     "string": FieldType(StringAdapter()),
-    "integer": FieldType(IntegerAdapter()),
+    "integer": FieldType(IntegerAdapter(), option_model=IntegerOptions),
     "number": FieldType(NumberAdapter()),
     "boolean": FieldType(BooleanAdapter()),
     "string_list": FieldType(StringListAdapter()),
@@ -945,6 +961,7 @@ __all__ = [
     "FieldValue",
     "FieldType",
     "IntegerAdapter",
+    "IntegerOptions",
     "IniFileBackend",
     "NumberAdapter",
     "ProviderManager",

--- a/src/pysigil/ui/options_form.py
+++ b/src/pysigil/ui/options_form.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, fields, is_dataclass
 from typing import Any, Mapping, get_args, get_origin, Union
+from types import UnionType
 
 from ..settings_metadata import TYPE_REGISTRY, FieldType
 from .widgets import EditorWidget
@@ -66,7 +67,7 @@ class OptionsForm(ttk.Frame):
     @staticmethod
     def _unwrap_optional(tp: Any) -> tuple[bool, Any]:
         origin = get_origin(tp)
-        if origin is Union:
+        if origin in (Union, UnionType):
             args = [a for a in get_args(tp) if a is not type(None)]
             if len(args) == 1:
                 return True, args[0]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,12 +24,12 @@ def test_register_and_set(tmp_path):
     info2 = a.register_provider("my-pkg")
     assert info2.provider_id == "my-pkg"
     h = a.handle("my-pkg")
-    h.add_field("retries", "integer", options={"min": 0})
+    h.add_field("retries", "integer", options={"minimum": 0})
     h.set("retries", 5)
     val = h.get("retries")
     assert val.value == 5
     assert val.source == "user"
-    assert h.fields()[0].options == {"min": 0}
+    assert h.fields()[0].options == {"minimum": 0}
     assert "my-pkg" in a.providers()
 
 

--- a/tests/test_author_adapter.py
+++ b/tests/test_author_adapter.py
@@ -17,9 +17,9 @@ def test_upsert_field_sets_options_and_default(tmp_path, monkeypatch):
     api.register_provider("demo", title="Demo")
 
     adapter = AuthorAdapter("demo")
-    adapter.upsert_field("alpha", "integer", options={"min": 0}, default=5)
+    adapter.upsert_field("alpha", "integer", options={"minimum": 0}, default=5)
 
     fields = {f.key: f for f in adapter.list_defined()}
-    assert fields["alpha"].options == {"min": 0}
+    assert fields["alpha"].options == {"minimum": 0}
     assert adapter.default_for_key("alpha") == 5
 

--- a/tests/test_options_form.py
+++ b/tests/test_options_form.py
@@ -22,6 +22,11 @@ class DemoOptions:
     tags: list[str]
 
 
+@dataclass
+class IntOptOptional:
+    minimum: int | None = None
+
+
 def _make_form(root):
     ft = FieldType(TYPE_REGISTRY["string"].adapter, option_model=DemoOptions)
     return OptionsForm(root, ft)
@@ -93,4 +98,19 @@ def test_custom_option_widget():
     form = OptionsForm(root, ft)
     form.set_values({"value": "foo"})
     assert form.get_values()["value"] == "foo"
+    root.destroy()
+
+
+@pytest.mark.skipif(tk is None, reason="tkinter not available")
+def test_optional_field_type():
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+    ft = FieldType(TYPE_REGISTRY["integer"].adapter, option_model=IntOptOptional)
+    form = OptionsForm(root, ft)
+    form.set_values(IntOptOptional(7))
+    assert form.get_values()["minimum"] == 7
+    form.set_values(IntOptOptional())
+    assert form.get_values()["minimum"] is None
     root.destroy()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -25,14 +25,27 @@ def test_register_add_set_get(tmp_path: Path) -> None:
         key="retries",
         type="integer",
         label="Retries",
-        options={"min": 0},
+        options={"minimum": 0},
     )
     orch.set_value("my-pkg", "retries", 5)
     eff = orch.get_effective("my-pkg")
     assert eff["retries"].value == 5
     assert eff["retries"].source == "user"
     spec = orch.reload_spec("my-pkg")
-    assert spec.fields[0].options == {"min": 0}
+    assert spec.fields[0].options == {"minimum": 0}
+
+
+def test_set_value_respects_minimum(tmp_path: Path) -> None:
+    orch = _make_orch(tmp_path)
+    orch.register_provider("pkg")
+    orch.add_field(
+        "pkg",
+        key="retries",
+        type="integer",
+        options={"minimum": 1},
+    )
+    with pytest.raises(ValidationError):
+        orch.set_value("pkg", "retries", 0)
 
 
 def test_edit_field_rename_migrates_value(tmp_path: Path) -> None:

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -21,11 +21,11 @@ def test_register_and_add_field(tmp_path):
         key="retries",
         type="integer",
         label="Retries",
-        options={"min": 0},
+        options={"minimum": 0},
     )
     add_field_spec(path, field)
     spec2 = load_provider_spec(path)
     assert len(spec2.fields) == 1
     assert spec2.fields[0].key == "retries"
     assert spec2.fields[0].type == "integer"
-    assert spec2.fields[0].options == {"min": 0}
+    assert spec2.fields[0].options == {"minimum": 0}

--- a/tests/test_settings_metadata.py
+++ b/tests/test_settings_metadata.py
@@ -48,7 +48,7 @@ def test_provider_manager_roundtrip():
                 key="retries",
                 type="integer",
                 label="Retries",
-                options={"min": 0},
+                options={"minimum": 0},
             )
         ],
     )
@@ -58,7 +58,7 @@ def test_provider_manager_roundtrip():
     state = mgr.effective()
     assert state["retries"].value == 3
     assert state["retries"].source == "project"
-    assert mgr.spec.fields[0].options == {"min": 0}
+    assert mgr.spec.fields[0].options == {"minimum": 0}
 
     mgr.set("retries", 5)
     assert backend.writes == [("demo", "retries", "5", "user", "settings.ini")]
@@ -68,6 +68,18 @@ def test_provider_manager_roundtrip():
 
     mgr.init("user")
     assert backend.sections == [("demo", "user", "settings.ini")]
+
+
+def test_integer_minimum_enforced():
+    spec = ProviderSpec(
+        provider_id="demo",
+        schema_version="0.1",
+        fields=[FieldSpec(key="count", type="integer", options={"minimum": 1})],
+    )
+    backend = DummyBackend()
+    mgr = ProviderManager(spec, backend)
+    with pytest.raises(ValueError):
+        mgr.set("count", 0)
 
 
 def test_ini_spec_backend_persists_options(tmp_path):


### PR DESCRIPTION
## Summary
- allow integer fields to specify an optional minimum value via `IntegerOptions`
- validate integer values against configured minimum
- extend OptionsForm to handle PEP 604 union annotations so optional options render correctly
- expand tests to cover minimum enforcement and optional option editing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5fe9fd1b88328bcb34dd8b3846e36