### PR TITLE
Load undiscovered author fields on demand

### DIFF
--- a/tests/manual/manual_author_gui.py
+++ b/tests/manual/manual_author_gui.py
@@ -1,4 +1,8 @@
-"""Manual helper to launch the author tools GUI."""
+"""Manual helper to launch the author tools GUI.
+
+Undiscovered provider fields are hidden by default. Expand the
+"Undiscovered" node in the tree to load and manage them when testing.
+"""
 
 from pysigil.ui.tk import App
 


### PR DESCRIPTION
## Summary
- show only defined fields in author tools tree by default
- add collapsed "Undiscovered" node that loads lazily when expanded
- document new behavior in manual GUI launcher

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b609e3abd08328b72eb22d013ffbba