### PR TITLE
docs: document dev links and auto discovery

### DIFF
--- a/AUTHORS_GUIDE.md
+++ b/AUTHORS_GUIDE.md
@@ -24,6 +24,9 @@ We use your **PEP 503 normalized** distribution name as the provider id (lowerca
 Sigil can auto-detect your package from the current directory using
 `pyprojroot` and your `pyproject.toml`.
 
+At runtime, providers are now discovered automatically by scanning installed
+distributions for `.sigil/metadata.ini`. No Python entry points are required.
+
 ```bash
 # From your repo root
 sigil author register --auto
@@ -113,12 +116,13 @@ ci_policy = ScopePolicy(scopes)
 
 ## Packaging tip
 
-When you publish, include `.sigil/settings.ini` in your wheel:
+When you publish, include `.sigil/settings.ini` and `.sigil/metadata.ini` in your
+wheel:
 
 ```toml
 # pyproject.toml (example)
 [tool.setuptools.package-data]
-"my_pkg" = [".sigil/settings.ini"]
+"my_pkg" = [".sigil/settings.ini", ".sigil/metadata.ini"]
 ```
 
 ## Troubleshooting

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -2,18 +2,26 @@
 
 (Everything you need to do; everything you automatically get. Nothing more.)
 
+Providers are auto-discovered by scanning installed distributions for
+`.sigil/metadata.ini` and `.sigil/settings.ini`, so there are no Python entry
+points or `pyproject.toml` hooks to maintain.
+
 | # | Action you take in your package | Exact snippet / path | What pysigil gives you for free |
 |---|--------------------------------|----------------------|--------------------------------|
-| 1 | Create a defaults file (INI only for MVP) | `mypkg/prefs/defaults.ini`<br><br>```ini
+| 1 | Create a defaults file under `.sigil` | `mypkg/.sigil/settings.ini`<br><br>```ini
 [db]
 host = localhost
 port = 5432
 ``` | Becomes the base layer of the preference chain. |
-| 2 | Declare that file in `pyproject.toml` | ```toml
-[tool.pysigil]
-defaults = "prefs/defaults.ini"
-``` | pysigil-Hub auto-discovers your package during import. |
-| 3 | (Optional but recommended) Expose helpers so callers never touch pysigil APIs | ```python
+| 2 | Register the package during development | ```bash
+sigil author register --auto  # or `sigil setup`
+``` | Dev links let Sigil find your defaults without installing the package. |
+| 3 | Ship settings and metadata files | ```toml
+# pyproject.toml
+[tool.setuptools.package-data]
+"mypkg" = [".sigil/settings.ini", ".sigil/metadata.ini"]
+``` | Installed distributions are scanned for these files—no Python entry points needed. |
+| 4 | (Optional) Expose helpers so callers never touch pysigil APIs | ```python
 # mypkg/__init__.py
 from pysigil.core import Sigil
 
@@ -21,7 +29,6 @@ _sigil = Sigil(__name__)  # __name__ == "mypkg"
 get_pref = _sigil.get_pref
 set_pref = _sigil.set_pref
 ``` | • One-line access:<br>`get_pref("db.host")`<br>• Handles env ▶ project ▶ user ▶ defaults without extra code. |
-| 4 | (Optional) ship metadata later | Add `prefs/defaults.meta.json` and set `meta = "prefs/defaults.meta.json"` under `[tool.pysigil]` | When the GUI arrives, titles, tool-tips and “secret” flags will show automatically. No impact on MVP. |
 
 ## What you get immediately
 
@@ -41,7 +48,9 @@ Files auto-created as needed.
 
 Zero runtime deps: pysigil is pure std-lib + your INI file.
 
-That’s it. Add one defaults file, one `[tool.sigil]` line, (optionally) four helper lines — and your package instantly gains a robust, chain-aware configuration system.
+That’s it. Add one defaults file, register a dev link, (optionally) four helper
+lines — and your package instantly gains a robust, chain-aware configuration
+system.
 
 ## Custom scopes
 


### PR DESCRIPTION
## Summary
- note that providers are discovered by scanning installed distributions instead of entry points
- explain registering dev links with `sigil author register` or `sigil setup`
- remind authors to ship `.sigil/settings.ini` and `.sigil/metadata.ini`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b60c3928688328bb9536198bbbf49e