### PR TITLE
Add Sigil toolkit helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ python -m pysigil --help
 ```
 
 ```python
-from pysigil.core import Sigil
+from pysigil import get_setting, init, set_setting
 
-sigil = Sigil("pysigil")
-get_pref = sigil.get_pref
-set_pref = sigil.set_pref
+init("pysigil")
+get_setting("ui.color")
+set_setting("ui.color", "blue")
 ```
 
 Once installed, try a few commands:

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -23,12 +23,10 @@ sigil author register --auto  # or `sigil setup`
 ``` | Installed distributions are scanned for these files—no Python entry points needed. |
 | 4 | (Optional) Expose helpers so callers never touch pysigil APIs | ```python
 # mypkg/__init__.py
-from pysigil.core import Sigil
+from pysigil import get_setting, init, set_setting
 
-_sigil = Sigil(__name__)  # __name__ == "mypkg"
-get_pref = _sigil.get_pref
-set_pref = _sigil.set_pref
-``` | • One-line access:<br>`get_pref("db.host")`<br>• Handles env ▶ project ▶ user ▶ defaults without extra code. |
+init(__name__)  # __name__ == "mypkg"
+``` | • One-line access:<br>`get_setting("db.host")`<br>• Handles env ▶ project ▶ user ▶ defaults without extra code. |
 
 Launch authoring tools without starting the main editor:
 
@@ -41,7 +39,7 @@ sigil author
 Fully merged prefs:
 `SIGIL_MYPKG_DB_HOST (env) → ./settings.ini (project) → ~/.config/mypkg/settings.ini (user) → your defaults.ini.`
 
-No boiler-plate: call `get_pref()` / `set_pref()` from anywhere in your code.
+No boiler-plate: call `get_setting()` / `set_setting()` from anywhere in your code.
 
 User tooling already works:
 

--- a/src/pysigil/__init__.py
+++ b/src/pysigil/__init__.py
@@ -1,5 +1,14 @@
 from .core import Sigil, SigilError
 from .merge_policy import parse_key
 from .policy import policy
+from .toolkit import get_setting, init, set_setting
 
-__all__ = ["Sigil", "SigilError", "parse_key", "policy"]
+__all__ = [
+    "Sigil",
+    "SigilError",
+    "parse_key",
+    "policy",
+    "init",
+    "get_setting",
+    "set_setting",
+]

--- a/src/pysigil/toolkit.py
+++ b/src/pysigil/toolkit.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .core import Sigil
+from .discovery import pep503_name
+
+__all__ = ["init", "get_setting", "set_setting"]
+
+_cache: dict[str, Sigil] = {}
+_current: str | None = None
+
+
+def init(app_name: str) -> Sigil:
+    """Initialise and cache a :class:`Sigil` instance for *app_name*.
+
+    Repeated calls for the same application return the cached instance and
+    switch the active application used by :func:`get_setting` and
+    :func:`set_setting`.
+    """
+    global _current
+    name = pep503_name(app_name)
+    _current = name
+    try:
+        return _cache[name]
+    except KeyError:
+        sigil = Sigil(app_name)
+        _cache[name] = sigil
+        return sigil
+
+
+def _current_sigil() -> Sigil:
+    if _current is None:
+        raise RuntimeError("call init(app_name) before accessing settings")
+    return _cache[_current]
+
+
+def get_setting(
+    key: str,
+    *,
+    cast: Callable[[str], Any] | None = None,
+    default: Any | None = None,
+) -> Any:
+    """Return the value for *key* from the active application."""
+    return _current_sigil().get_pref(key, cast=cast, default=default)
+
+
+def set_setting(
+    key: str,
+    value: Any,
+    *,
+    scope: str | None = None,
+) -> None:
+    """Set *key* to *value* in the active application."""
+    _current_sigil().set_pref(key, value, scope=scope)

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pysigil import get_setting, init, set_setting
+
+
+def test_cached_instances(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+    sig1 = init("demo")
+    set_setting("section.value", "1")
+    assert get_setting("section.value") == 1
+
+    sig2 = init("demo")
+    assert sig1 is sig2
+
+    init("other")
+    assert get_setting("section.value") is None
+    set_setting("section.value", "2")
+    assert get_setting("section.value") == 2
+
+    init("demo")
+    assert get_setting("section.value", cast=int) == 1


### PR DESCRIPTION
## Summary
- add toolkit helpers that cache a `Sigil` instance per application
- expose `init`, `get_setting` and `set_setting` at the package root
- document toolkit usage in README and integration guide
- test toolkit caching behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc772869988328917f565c4d91265c