### PR TITLE
Fix author GUI not exiting

### DIFF
--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -236,7 +236,8 @@ def launch_author_ui(_ctx: object) -> int:  # pragma: no cover - GUI interaction
 
     root = tk.Tk()
     root.withdraw()
-    AuthorTools(root, core)
+    win = AuthorTools(root, core)
+    win.protocol("WM_DELETE_WINDOW", root.destroy)
     root.mainloop()
     return 0
 


### PR DESCRIPTION
## Summary
- close root window when author tools UI is dismissed

## Testing
- `pytest`
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `python tools/validate_meta.py accio_data prefs/defaults.meta.csv` *(fails: No module named 'pysigil.helpers')*

------
https://chatgpt.com/codex/tasks/task_e_68bf7c3812c08328b1d7dc4eb35acb05