### PR TITLE
feat: add section metadata and sorting support

### DIFF
--- a/src/pysigil/ui/tk/author_tools.py
+++ b/src/pysigil/ui/tk/author_tools.py
@@ -280,6 +280,19 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         ft = TYPE_REGISTRY.get(info.type)
         self._build_type_section(ft, default, info.options)
 
+        # Grouping ------------------------------------------------------
+        group_fr = ttk.LabelFrame(self._form, text="Grouping")
+        group_fr.pack(fill="x", pady=(0, 6))
+        self._section_var = tk.StringVar(value=info.section or "")
+        ttk.Label(group_fr, text="Section:").grid(row=0, column=0, sticky="w")
+        ttk.Entry(group_fr, textvariable=self._section_var).grid(row=0, column=1, sticky="ew")
+        self._order_var = tk.StringVar(
+            value="" if info.order is None else str(info.order)
+        )
+        ttk.Label(group_fr, text="Order:").grid(row=1, column=0, sticky="w")
+        ttk.Entry(group_fr, textvariable=self._order_var).grid(row=1, column=1, sticky="ew")
+        group_fr.columnconfigure(1, weight=1)
+
         # Actions --------------------------------------------------------
         actions = ttk.Frame(self._form)
         actions.pack(fill="x", pady=(0, 6))
@@ -326,6 +339,16 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         desc_short = self._desc_short_var.get().strip() or None
         description = self._desc_text.get("1.0", "end").strip() or None
         options = self._collect_options()
+        section = self._section_var.get().strip() or None
+        order_val = self._order_var.get().strip()
+        order = None
+        if order_val:
+            try:
+                order = int(order_val)
+            except ValueError:
+                if messagebox is not None:
+                    messagebox.showerror("Invalid order", "Order must be an integer", parent=self)
+                return
         default = None
         if self._value_widget is not None and hasattr(self._value_widget, "get_value"):
             default = self._value_widget.get_value()  # type: ignore[attr-defined]
@@ -353,6 +376,10 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
             kwargs["description"] = description
         if "options" in sig.parameters and options is not None:
             kwargs["options"] = options
+        if "section" in sig.parameters:
+            kwargs["section"] = section
+        if "order" in sig.parameters and order is not None:
+            kwargs["order"] = order
         if "default" in sig.parameters and default is not None:
             kwargs["default"] = default
         if desc_short is not None and len(desc_short) > SHORT_DESC_MAX:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -119,6 +119,21 @@ def test_validate_all_reports_errors(tmp_path: Path) -> None:
     assert errors["num"] is not None
 
 
+def test_patch_fields_and_sections(tmp_path: Path) -> None:
+    orch = _make_orch(tmp_path)
+    orch.register_provider("pkg")
+    orch.add_field("pkg", key="a", type="string", section="Old", order=1)
+    orch.add_field("pkg", key="b", type="string", section="Old", order=2)
+    orch.patch_fields("pkg", [{"key": "b", "section": "New", "order": 5}])
+    spec = orch.reload_spec("pkg")
+    b_field = [f for f in spec.fields if f.key == "b"][0]
+    assert b_field.section == "New" and b_field.order == 5
+    orch.set_sections_order("pkg", ["New", "Old"])
+    assert orch.get_sections_order("pkg") == ["New", "Old"]
+    orch.set_sections_collapsed("pkg", ["Old"])
+    assert orch.get_sections_collapsed("pkg") == ["Old"]
+
+
 def test_set_many_atomic(tmp_path: Path) -> None:
     orch = _make_orch(tmp_path)
     orch.register_provider("pkg")

--- a/tests/test_settings_metadata.py
+++ b/tests/test_settings_metadata.py
@@ -97,6 +97,27 @@ def test_ini_spec_backend_persists_options(tmp_path):
     assert loaded.fields[0].options == {"choices": ["a", "b"]}
 
 
+def test_ini_spec_backend_persists_sections(tmp_path):
+    backend = IniSpecBackend(user_dir=tmp_path)
+    spec = ProviderSpec(
+        provider_id="demo",
+        schema_version="1",
+        sections_order=["Basics", "Advanced"],
+        sections_collapsed=["Advanced"],
+        fields=[
+            FieldSpec(
+                key="endpoint", type="string", section="Basics", order=100
+            )
+        ],
+    )
+    backend.create_spec(spec)
+    loaded = backend.get_spec("demo")
+    assert loaded.sections_order == ("Basics", "Advanced")
+    assert loaded.sections_collapsed == ("Advanced",)
+    assert loaded.fields[0].section == "Basics"
+    assert loaded.fields[0].order == 100
+
+
 def test_ini_file_backend(tmp_path):
     user_dir = tmp_path / "user"
     project_dir = tmp_path / "proj"


### PR DESCRIPTION
## Summary
- track field `section` and `order` in provider specs
- allow providers to set section ordering and collapsed hints
- expose section metadata in authoring UI and bulk patch helpers

## Testing
- `pre-commit run --files src/pysigil/settings_metadata.py src/pysigil/api.py src/pysigil/orchestrator.py src/pysigil/ui/author_adapter.py src/pysigil/ui/tk/author_tools.py tests/test_settings_metadata.py tests/test_orchestrator.py` *(command failed: pre-commit: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4a1d54bc883288b94750eb1a1a553