### PR TITLE
Remove lock icon and restore edit button

### DIFF
--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -223,10 +223,12 @@ class App:
                         info.key,
                         self.on_pill_click,
                         compact=self.compact,
+                        on_edit_click=self._open_edit_dialog,
                     )
                     self.field_rows[info.key] = row
                 else:
                     row.set_compact(self.compact)
+                    row._on_edit_click = self._open_edit_dialog
                 if hasattr(row, "update_metadata"):
                     try:
                         row.update_metadata(info)  # type: ignore[attr-defined]

--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -35,11 +35,13 @@ class FieldRow(ttk.Frame):
         on_pill_click: Callable[[str, str], None],
         *,
         compact: bool = True,
+        on_edit_click: Callable[[str], None] | None = None,
     ) -> None:
         super().__init__(master)
         self.adapter = adapter
         self.key = key
         self._on_pill_click = on_pill_click
+        self._on_edit_click = on_edit_click
         self.compact = compact
 
         # container for key + info button
@@ -93,6 +95,14 @@ class FieldRow(ttk.Frame):
         # container for scope pills
         self.pills = ttk.Frame(self)
         self.pills.grid(row=0, column=2, sticky="w")
+
+        # edit action button
+        self.btn_edit = ttk.Button(
+            self,
+            text="Edit…",
+            command=lambda: self._on_edit_click(self.key) if self._on_edit_click else None,
+        )
+        self.btn_edit.grid(row=0, column=3, padx=4)
 
         self.columnconfigure(1, weight=1)
 

--- a/src/pysigil/ui/tk/widgets.py
+++ b/src/pysigil/ui/tk/widgets.py
@@ -143,8 +143,7 @@ class PillButton(tk.Canvas):
         if self.font is None:
             return 64
         text_w = self.font.measure(self.text)
-        extra = 10 if self.locked else 0
-        return max(64, text_w + self.pad_x * 2 + extra)
+        return max(64, text_w + self.pad_x * 2)
 
     def _draw(self, initial: bool = False) -> None:
         w = self._measure_width()
@@ -177,8 +176,6 @@ class PillButton(tk.Canvas):
         r = self.rad
         self._round_rect(1, 1, w - 1, 26, r, fill=fill, outline=outline, width=border_w)
         self.create_text(w / 2, 14, text=self.text, fill=fg, font=self.font)
-        if self.locked:
-            self.create_text(w - 10, 14, text="\u1F512", fill=fg, font=self.font)
         if self.focus_displayof() is self:
             self.create_rectangle(3, 3, w - 3, 24, outline="#111", dash=(2, 2))
 


### PR DESCRIPTION
## Summary
- drop unused lock glyph from scope pills
- add back edit button for field rows and wire it to editing dialog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4a77fba6c8328a3e929834a64cf17