### PR TITLE
Add section order dialog to author GUI

### DIFF
--- a/src/pysigil/ui/tk/author_tools.py
+++ b/src/pysigil/ui/tk/author_tools.py
@@ -16,6 +16,7 @@ from ..author_adapter import AuthorAdapter, FieldInfo
 from ..options_form import OptionsForm
 from ..core import AppCore
 from ..value_parser import parse_field_value
+from .dialogs import SectionOrderDialog
 
 
 class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
@@ -68,6 +69,9 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         entry = ttk.Entry(search, textvariable=self._search_var)
         entry.pack(fill="x", side="left", expand=True)
         ttk.Button(search, text="Add", command=self._on_add).pack(side="right", padx=(4, 0))
+        ttk.Button(search, text="Sections…", command=self._open_sections_dialog).pack(
+            side="right", padx=(4, 0)
+        )
         self._search_var.trace_add("write", lambda *_: self._reload_tree())
 
         self._tree = ttk.Treeview(self._left, show="tree")
@@ -131,6 +135,9 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         if node == "undiscovered" and not self._undiscovered_loaded:
             self._undiscovered_loaded = True
             self._reload_tree()
+
+    def _open_sections_dialog(self) -> None:  # pragma: no cover - simple UI callback
+        SectionOrderDialog(self, self.adapter)
 
     # ------------------------------------------------------------------
     def _build_type_section(

--- a/src/pysigil/ui/tk/dialogs.py
+++ b/src/pysigil/ui/tk/dialogs.py
@@ -13,6 +13,8 @@ except Exception:  # pragma: no cover - fallback when tkinter missing
     ttk = None  # type: ignore
 
 from ..provider_adapter import ProviderAdapter, ValueInfo
+from ..author_adapter import AuthorAdapter
+from ..sections import compute_section_order
 from ..value_parser import parse_field_value
 
 
@@ -155,3 +157,68 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
         entry = self.entries.get(scope)
         if entry is not None:
             entry.delete(0, "end")
+
+
+class SectionOrderDialog(tk.Toplevel):  # pragma: no cover - simple UI wrapper
+    """Dialog allowing authors to reorder configuration sections."""
+
+    def __init__(self, master: tk.Widget, adapter: AuthorAdapter) -> None:
+        super().__init__(master)
+        self.title("Section Order")
+        self.transient(master)
+        self.grab_set()
+        self.resizable(False, False)
+        self.adapter = adapter
+
+        fields = adapter.list_defined()
+        order = compute_section_order(fields, adapter.get_sections_order())
+        self._sections = list(order)
+
+        body = ttk.Frame(self, padding=12)
+        body.pack(fill="both", expand=True)
+
+        self._list = tk.Listbox(body, exportselection=False)
+        self._list.pack(side="left", fill="both", expand=True)
+        for sec in self._sections:
+            self._list.insert("end", sec)
+
+        btns = ttk.Frame(body)
+        btns.pack(side="left", fill="y", padx=(6, 0))
+        ttk.Button(btns, text="Up", command=self._move_up).pack(fill="x")
+        ttk.Button(btns, text="Down", command=self._move_down).pack(fill="x", pady=4)
+
+        actions = ttk.Frame(self)
+        actions.pack(fill="x", padx=12, pady=(0, 12))
+        ttk.Button(actions, text="Save", command=self._save).pack(side="right")
+        ttk.Button(actions, text="Close", command=self.destroy).pack(side="right", padx=(0, 6))
+
+    # -- helpers ---------------------------------------------------------
+    def _move(self, delta: int) -> None:
+        sel = self._list.curselection()
+        if not sel:
+            return
+        idx = sel[0]
+        new_idx = max(0, min(len(self._sections) - 1, idx + delta))
+        if new_idx == idx:
+            return
+        self._sections[idx], self._sections[new_idx] = (
+            self._sections[new_idx],
+            self._sections[idx],
+        )
+        self._list.delete(0, "end")
+        for sec in self._sections:
+            self._list.insert("end", sec)
+        self._list.selection_set(new_idx)
+
+    def _move_up(self) -> None:
+        self._move(-1)
+
+    def _move_down(self) -> None:
+        self._move(1)
+
+    def _save(self) -> None:
+        try:
+            self.adapter.set_sections_order(self._sections)
+        except Exception:
+            pass
+        self.destroy()

--- a/tests/ui/test_sections_order_dialog.py
+++ b/tests/ui/test_sections_order_dialog.py
@@ -1,0 +1,43 @@
+try:  # pragma: no cover - tkinter availability depends on the env
+    import tkinter as tk
+except Exception:  # pragma: no cover - fallback when tkinter missing
+    tk = None  # type: ignore
+
+import pytest
+
+from pysigil.ui.author_adapter import FieldInfo
+from pysigil.ui.tk.dialogs import SectionOrderDialog
+
+
+class DummyAdapter:
+    def __init__(self) -> None:
+        self.saved: list[str] | None = None
+
+    def list_defined(self):
+        return [
+            FieldInfo(key="a", type="string", section="One"),
+            FieldInfo(key="b", type="string", section="Two"),
+        ]
+
+    def get_sections_order(self):
+        return ["One", "Two"]
+
+    def set_sections_order(self, seq):
+        self.saved = list(seq)
+
+
+def test_section_order_dialog_moves_and_saves():
+    if tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+
+    adapter = DummyAdapter()
+    dlg = SectionOrderDialog(root, adapter)
+    dlg._list.selection_set(1)
+    dlg._move_up()
+    dlg._save()
+    assert adapter.saved == ["Two", "One"]
+    root.destroy()


### PR DESCRIPTION
## Summary
- add Section Order dialog with up/down controls for arranging provider sections
- expose new "Sections…" button in Author Tools to open the reorder dialog
- cover dialog behavior with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4a94af19c832885ce4190dec6a02f