### PR TITLE
Handle CSV BOM and preserve selection in ListEditor

### DIFF
--- a/src/pysigil/ui/tk/list_editor.py
+++ b/src/pysigil/ui/tk/list_editor.py
@@ -259,17 +259,21 @@ class ListEditor(ttk.Frame):  # pragma: no cover - exercised via tk tests
         if offset > 0:
             indices.reverse()
         moved = False
+        new_selection: list[int] = []
         for idx in indices:
             new_idx = idx + offset
             if not (0 <= new_idx < len(self._items)):
+                new_selection.append(idx)
                 continue
             self._items[idx], self._items[new_idx] = (
                 self._items[new_idx],
                 self._items[idx],
             )
+            new_selection.append(new_idx)
             moved = True
         if moved:
             self._refresh_tree()
+            self._tree.selection_set([str(i) for i in sorted(new_selection)])
             self.event_generate("<<ListChanged>>")
 
     def sort_items(self) -> None:
@@ -344,7 +348,8 @@ class ListEditor(ttk.Frame):  # pragma: no cover - exercised via tk tests
         path = filedialog.askopenfilename(parent=self, filetypes=[("CSV", "*.csv")])
         if not path:
             return
-        with open(path, newline="", encoding="utf8") as f:
+        # ``utf8-sig`` transparently strips a UTF-8 BOM if present
+        with open(path, newline="", encoding="utf8-sig") as f:
             reader = csv.reader(f)
             rows = list(reader)
         if self.mode != "simple" and rows and len(rows[0]) == len(self._columns):

--- a/tests/ui/test_list_editor.py
+++ b/tests/ui/test_list_editor.py
@@ -5,6 +5,7 @@ try:
 except Exception:  # pragma: no cover - tkinter missing
     tk = None  # type: ignore
 
+import pysigil.ui.tk.list_editor as le
 from pysigil.ui.tk.list_editor import ListEditor, ListEditDialog
 
 
@@ -40,4 +41,35 @@ def test_list_edit_dialog_result():
     dlg = ListEditDialog(root, value=["x"])
     dlg._on_ok()
     assert dlg.result == ["x"]
+    root.destroy()
+
+
+def test_list_editor_import_bom(tmp_path, monkeypatch):
+    if tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = _make_root()
+    except Exception:
+        pytest.skip("no display available")
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("\ufeffitem1\nitem2\n", encoding="utf-8")
+    monkeypatch.setattr(le.filedialog, "askopenfilename", lambda **kwargs: str(csv_path))
+    editor = ListEditor(root, value=[])
+    editor._on_import()
+    assert editor.get_list() == ["item1", "item2"]
+    root.destroy()
+
+
+def test_list_editor_move_preserves_selection():
+    if tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = _make_root()
+    except Exception:
+        pytest.skip("no display available")
+    editor = ListEditor(root, value=["a", "b", "c"])
+    editor._tree.selection_set("1")
+    editor._move(-1)
+    assert editor.get_list() == ["b", "a", "c"]
+    assert editor._tree.selection() == ("0",)
     root.destroy()


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM when importing CSVs in ListEditor
- keep items selected after reorder operations
- test CSV imports with BOM and selection persistence

## Testing
- `pre-commit run --files src/pysigil/ui/tk/list_editor.py tests/ui/test_list_editor.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not connect to proxy)*
- `pytest tests/ui/test_list_editor.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5935e6c588328ada9217749761f22