### PR TITLE
Show field metadata in edit dialog

### DIFF
--- a/src/pysigil/ui/tk/dialogs.py
+++ b/src/pysigil/ui/tk/dialogs.py
@@ -41,7 +41,9 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
         on_edit_remove: Callable[[str, str], None] | None = None,
     ) -> None:
         super().__init__(master)
-        self.title(f"Edit — {key}")
+        info = adapter.field_info(key)
+        label = info.label or key
+        self.title(f"Edit — {label}")
         self.transient(master)
         self.grab_set()
         self.resizable(False, False)
@@ -53,8 +55,14 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
         palette = get_palette()
         self.configure(bg=palette["bg"])  # type: ignore[call-arg]
 
-        ttk.Label(self, text=key, style="Title.TLabel").pack(
-            anchor="w", padx=18, pady=(12, 6)
+        ttk.Label(self, text=label, style="Title.TLabel").pack(
+            anchor="w", padx=18, pady=(12, 0)
+        )
+        ttk.Style(self).configure(
+            "Key.TLabel", background=palette["bg"], foreground=palette["hdr_muted"]
+        )
+        ttk.Label(self, text=key, style="Key.TLabel").pack(
+            anchor="w", padx=18, pady=(0, 6)
         )
         body = ttk.Frame(self, padding=12, style="Card.TFrame")
         body.pack(fill="both", expand=True, padx=18, pady=(0, 12))
@@ -154,6 +162,29 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
                 row += 1
 
             self.entries[scope] = entry
+            row += 1
+        ttk.Style(self).configure(
+            "Desc.TLabel", background=palette["card"], foreground=palette["ink_muted"]
+        )
+        if info.description_short:
+            ttk.Label(
+                body,
+                text=info.description_short,
+                style="Desc.TLabel",
+                wraplength=400,
+                anchor="w",
+                justify="left",
+            ).grid(row=row, column=0, columnspan=4, sticky="w", pady=(12, 0))
+            row += 1
+        if info.description:
+            ttk.Label(
+                body,
+                text=info.description,
+                style="Desc.TLabel",
+                wraplength=400,
+                anchor="w",
+                justify="left",
+            ).grid(row=row, column=0, columnspan=4, sticky="w")
             row += 1
 
         ttk.Button(

--- a/tests/ui/test_edit_dialog.py
+++ b/tests/ui/test_edit_dialog.py
@@ -7,6 +7,7 @@ except Exception:  # pragma: no cover - tkinter missing
     tk = None  # type: ignore
     ttk = None  # type: ignore
 
+from pysigil.api import FieldInfo
 from pysigil.ui.tk.dialogs import EditDialog
 from pysigil.ui.provider_adapter import ValueInfo
 
@@ -27,6 +28,15 @@ class DummyAdapter:
     def is_overlay(self, scope):
         return False
 
+    def field_info(self, key):
+        return FieldInfo(
+            key=key,
+            type="string",
+            label="Alpha Label",
+            description_short="Short description",
+            description="Long description",
+        )
+
 
 def test_edit_dialog_default_readonly():
     if tk is None:
@@ -44,5 +54,26 @@ def test_edit_dialog_default_readonly():
     btn_remove = body.grid_slaves(row=row, column=3)[0]
     assert btn_save.instate(["disabled"])
     assert btn_remove.instate(["disabled"])
+    dlg.destroy()
+    root.destroy()
+
+
+def test_edit_dialog_shows_metadata():
+    if tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+    dlg = EditDialog(root, DummyAdapter(), "alpha")
+    assert dlg.title() == "Edit — Alpha Label"
+    children = dlg.winfo_children()
+    texts = [w.cget("text") for w in children if isinstance(w, ttk.Label)]
+    assert "Alpha Label" in texts
+    assert "alpha" in texts
+    body = next(w for w in children if isinstance(w, ttk.Frame))
+    body_texts = [w.cget("text") for w in body.winfo_children() if isinstance(w, ttk.Label)]
+    assert "Short description" in body_texts
+    assert "Long description" in body_texts
     dlg.destroy()
     root.destroy()


### PR DESCRIPTION
## Summary
- Use field label for edit dialog title and display key beneath it
- Render short and long descriptions under the scope fields for extra context
- Test dialog metadata display and update adapter stub

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5f7b0fd8083289381ec4aed589af5