### PR TITLE
Ensure provider adapter tests use temp config

### DIFF
--- a/tests/ui/test_provider_adapter.py
+++ b/tests/ui/test_provider_adapter.py
@@ -22,6 +22,8 @@ def _setup_adapter(tmp_path, monkeypatch):
     orch = Orchestrator(spec_backend=spec, config_backend=cfg)
     monkeypatch.setattr(api, "_ORCH", orch, raising=False)
     monkeypatch.setattr("pysigil.ui.provider_adapter.policy", pol, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.delenv("SIGIL_APP_NAME", raising=False)
     adapter = ProviderAdapter()
     api.register_provider("demo", title="Demo")
     handle = api.handle("demo")


### PR DESCRIPTION
## Summary
- point `XDG_CONFIG_HOME` at the temporary config directory in the provider adapter test setup so link discovery reads the sandboxed path
- clear `SIGIL_APP_NAME` during setup to avoid leaking a user override into the tests

## Testing
- pytest tests/ui/test_provider_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68cf27eb15b883289441b46e584e9736