### PR TITLE
Add tests for provider defaults and merge policy helpers

### DIFF
--- a/tests/test_io_config_defaults.py
+++ b/tests/test_io_config_defaults.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+from pysigil.io_config import DefaultsFormatError, IniIOError, load_provider_defaults
+
+
+@pytest.fixture
+def package_builder(tmp_path, monkeypatch):
+    created: list[str] = []
+
+    def build(
+        name: str,
+        *,
+        ini_content: str | None = None,
+        create_sigil_dir: bool = False,
+    ) -> tuple[str, Path]:
+        pkg_dir = tmp_path / name
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+        if create_sigil_dir:
+            (pkg_dir / ".sigil").mkdir()
+        if ini_content is not None:
+            sigil_dir = pkg_dir / ".sigil"
+            sigil_dir.mkdir(exist_ok=True)
+            (sigil_dir / "settings.ini").write_text(ini_content, encoding="utf-8")
+        monkeypatch.syspath_prepend(str(tmp_path))
+        importlib.invalidate_caches()
+        sys.modules.pop(name, None)
+        created.append(name)
+        return name, pkg_dir
+
+    yield build
+
+    for name in created:
+        sys.modules.pop(name, None)
+
+
+def test_load_provider_defaults_missing_package() -> None:
+    result = load_provider_defaults("provider", "pkg_does_not_exist")
+    assert result == {}
+
+
+def test_load_provider_defaults_without_settings(package_builder) -> None:
+    name, _ = package_builder("pkg_without_defaults")
+    result = load_provider_defaults("provider", name)
+    assert result == {}
+
+
+def test_load_provider_defaults_empty_directory(package_builder) -> None:
+    name, _ = package_builder("pkg_with_empty_dir", create_sigil_dir=True)
+    result = load_provider_defaults("provider", name)
+    assert result == {}
+
+
+def test_load_provider_defaults_missing_provider_section(package_builder) -> None:
+    name, _ = package_builder(
+        "pkg_missing_provider",
+        ini_content="[other]\nvalue = 1\n",
+    )
+    with pytest.raises(DefaultsFormatError):
+        load_provider_defaults("provider", name)
+
+
+def test_load_provider_defaults_with_pysigil_section(package_builder) -> None:
+    name, _ = package_builder(
+        "pkg_with_pysigil",
+        ini_content=(
+            "[provider]\n"
+            "alpha = one\n"
+            "beta = two\n"
+            "\n"
+            "[pysigil]\n"
+            "scope = project\n"
+        ),
+    )
+    result = load_provider_defaults("provider", name)
+    assert result == {
+        "provider": {"alpha": "one", "beta": "two"},
+        "pysigil": {"scope": "project"},
+    }
+
+
+def test_load_provider_defaults_provider_only(package_builder) -> None:
+    name, _ = package_builder(
+        "pkg_provider_only",
+        ini_content="[provider]\nvalue = test\n",
+    )
+    result = load_provider_defaults("provider", name)
+    assert result == {"provider": {"value": "test"}}
+
+
+def test_load_provider_defaults_malformed_content(package_builder) -> None:
+    name, _ = package_builder(
+        "pkg_malformed",
+        ini_content="not a valid ini file",
+    )
+    with pytest.raises(IniIOError):
+        load_provider_defaults("provider", name)

--- a/tests/test_merge_policy_helpers.py
+++ b/tests/test_merge_policy_helpers.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+from pysigil.merge_policy import KeyPath, parse_key, read_env
+
+
+def test_parse_key_tuple_passthrough() -> None:
+    key: KeyPath = ("section", "value")
+    assert parse_key(key) is key
+
+
+def test_parse_key_splits_dot_and_underscore() -> None:
+    assert parse_key("section.option") == ("section", "option")
+    assert parse_key("section_option") == ("section", "option")
+
+
+def test_parse_key_rejects_empty_segments() -> None:
+    with pytest.raises(ValueError):
+        parse_key("section..option")
+    with pytest.raises(ValueError):
+        parse_key("section__option")
+    with pytest.raises(ValueError):
+        parse_key("section._option")
+
+
+def test_read_env_uses_sanitized_prefix(monkeypatch) -> None:
+    monkeypatch.setenv("SIGIL_MY_APP_OPTION", "value")
+    monkeypatch.setenv("SIGIL_MY_APP_SECTION_VALUE", "42")
+    monkeypatch.setenv("SIGIL_OTHER_SECTION_VALUE", "ignored")
+
+    result = read_env("my-app")
+
+    assert result == {
+        ("option",): "value",
+        ("section", "value"): "42",
+    }
+
+
+def test_read_env_supports_dotted_keys(monkeypatch) -> None:
+    monkeypatch.setenv("SIGIL_SAMPLE_DB.URL", "postgres")
+
+    result = read_env("sample")
+
+    assert result == {("db", "url"): "postgres"}
+
+
+def test_read_env_raises_on_invalid_key(monkeypatch) -> None:
+    monkeypatch.setenv("SIGIL_SAMPLE_BAD__KEY", "oops")
+
+    with pytest.raises(ValueError):
+        read_env("sample")


### PR DESCRIPTION
## Summary
- add coverage for load_provider_defaults across valid defaults, missing sections, and malformed files
- test parse_key and read_env helpers for tuple passthrough, splitting rules, and environment prefix handling

## Testing
- pytest tests/test_io_config_defaults.py tests/test_merge_policy_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68cf2a4284a0832896691d1c523b6bf1